### PR TITLE
chore: migrate to cdklabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,23 +39,34 @@ execute all tasks concurrently:
 The following sections describe each stage and the configuration options
 available:
 
-1. [Source](#source)
-   - [CodeCommit](#codecommit)
-   - [GitHub](#github)
-1. [Pull Request Builds](#pull-request-builds)
-1. [Build](#build)
-1. [Tests](#tests)
-1. [Publish](#publish)
-   - [npm.js](#npmjs)
-   - [NuGet](#nuget)
-   - [Maven Central](#maven-central)
-   - [PyPi](#pypi)
-   - [GitHub Releases](#github-releases)
-   - [GitHub Pages](#github-pages)
-1. [Metrics](#metrics)
-1. [Automatic Bumps and Pull Request Builds](#automatic-bumps-and-pull-request-builds)
-1. [Failure Notifications](#failure-notifications)
-1. [ECR Mirror](#ecr-mirror)
+- [aws-delivlib](#aws-delivlib)
+- [Pipeline Structure](#pipeline-structure)
+- [Installation](#installation)
+- [Source](#source)
+  - [`repo`: Source Repository (required)](#repo-source-repository-required)
+  - [`branch`: Source Control Branch (optional)](#branch-source-control-branch-optional)
+- [Pull Request Builds](#pull-request-builds)
+- [Build](#build)
+  - [`buildSpec`: Build Script (optional)](#buildspec-build-script-optional)
+  - [`buildImage`: Build container image (optional)](#buildimage-build-container-image-optional)
+  - [`env`: Build environment variables (optional)](#env-build-environment-variables-optional)
+  - [Other Build Options](#other-build-options)
+- [Tests](#tests)
+- [Publish](#publish)
+  - [npm.js (JavaScript)](#npmjs-javascript)
+  - [NuGet (.NET)](#nuget-net)
+  - [Maven Central (Java)](#maven-central-java)
+  - [PyPI (Python)](#pypi-python)
+  - [GitHub Releases](#github-releases)
+  - [GitHub Pages](#github-pages)
+- [Metrics](#metrics)
+- [Automatic Bumps and Pull Request Builds](#automatic-bumps-and-pull-request-builds)
+  - [GitHub Access](#github-access)
+  - [Automatic Bumps](#automatic-bumps)
+- [Failure Notifications](#failure-notifications)
+- [ECR Mirror](#ecr-mirror)
+- [Contributing](#contributing)
+- [License](#license)
 
 
 ## Installation
@@ -137,7 +148,7 @@ import cdk = require('@aws-cdk/core');
 
 new delivlib.Pipeline(this, 'MyPipeline', {
   repo: new delivlib.GitHubRepo({
-    repository: 'awslabs/aws-delivlib',
+    repository: 'cdklabs/aws-delivlib',
     token: cdk.SecretValue.secretsManager('my-github-token'),
   }),
   // ...

--- a/lib/shellable.ts
+++ b/lib/shellable.ts
@@ -476,7 +476,7 @@ export class WindowsPlatform extends ShellPlatform {
 
   public prebuildCommands(assumeRole?: AssumeRole, _useRegionalStsEndpoints?: boolean): string[] {
     if (assumeRole) {
-      throw new Error('assumeRole is not supported on Windows: https://github.com/awslabs/aws-delivlib/issues/57');
+      throw new Error('assumeRole is not supported on Windows: https://github.com/cdklabs/aws-delivlib/issues/57');
     }
 
     return [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-delivlib",
   "version": "12.4.3",
-  "homepage": "https://github.com/awslabs/aws-delivlib",
+  "homepage": "https://github.com/cdklabs/aws-delivlib",
   "description": "A fabulous library for defining continuous pipelines for building, testing and releasing code libraries.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/awslabs/aws-delivlib.git"
+    "url": "https://github.com/cdklabs/aws-delivlib.git"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/pipeline/delivlib.ts
+++ b/pipeline/delivlib.ts
@@ -21,7 +21,7 @@ export class DelivLibPipelineStack extends Stack {
     super(parent, id, props);
 
     const github = new delivlib.WritableGitHubRepo({
-      repository: 'awslabs/aws-delivlib',
+      repository: 'cdklabs/aws-delivlib',
       tokenSecretArn: 'arn:aws:secretsmanager:us-east-1:712950704752:secret:github-token-nnAqfW',
       commitEmail: 'aws-cdk-dev+delivlib@amazon.com',
       commitUsername: 'aws-cdk-dev',


### PR DESCRIPTION
Updates required to migrate to the new `cdklabs` GitHub organization

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
