### PR TITLE
fix: reuse same repository for multiple tags

### DIFF
--- a/lib/registry-sync/mirror-source.ts
+++ b/lib/registry-sync/mirror-source.ts
@@ -110,7 +110,7 @@ export abstract class MirrorSource {
     return new DirectoryMirrorSource();
   }
 
-  private constructor(private readonly repositoryName: string, private readonly tag: string, private readonly directory?: string) {
+  private constructor(protected readonly repositoryName: string, protected readonly tag: string, protected readonly directory?: string) {
   }
 
   /**


### PR DESCRIPTION
The previous implementation for "mirror multiple tags from the same
repository" was broken: it tried to create a repository per repo×tag,
instead of simply creating a repository per repository and mirroring
all the desired tags inside.

A subsequent problem would be that the construct identifiers of the
two sister repos would conflict, and cause problems in our ops codebase
where the repos are created in a separate stack (and hence lead to
Export rename trouble).

Simplify by doing a repo-per-repo and mirroring multiple tags inside
that repo.

This change is necessary to unblock `delivlib` progress inside cdk-ops.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
