### PR TITLE
feat(registry-sync): docker build time variables

### DIFF
--- a/test/registry-sync/mirror-source.test.ts
+++ b/test/registry-sync/mirror-source.test.ts
@@ -173,5 +173,31 @@ describe('RegistryImageSource', () => {
         },
       });
     });
+
+    test('build args', () => {
+      // GIVEN
+      const stack = new Stack();
+      const ecrRegistry = 'myregistry';
+      const source = MirrorSource.fromDir(path.join(__dirname, 'docker-asset'), 'myrepository', {
+        buildArgs: {
+          arg1: 'val1',
+          arg2: 'val2',
+        },
+      });
+      const syncJob = new codebuild.Project(stack, 'SyncJob', {
+        buildSpec: codebuild.BuildSpec.fromObject({}),
+      });
+
+      // WHEN
+      const result = source.bind({
+        scope: stack,
+        ecrRegistry,
+        syncJob,
+      });
+
+      // THEN
+      const expected = 'docker build --pull -t myregistry/myrepository:latest --build-arg arg1=val1 --build-arg arg2=val2 myrepository';
+      expect(result.commands[2]).toEqual(expected);
+    });
   });
 });


### PR DESCRIPTION
Allow build time variables, aka build-arg, to be configured when the
docker image is being built from a local directory.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
