### PR TITLE
feat(pipeline): improved pipeline action failure metrics

### DIFF
--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -472,7 +472,7 @@ export class Pipeline extends Construct {
   /**
    * The metric that tracks pipeline failures.
    */
-  public metricFailures(options: cloudwatch.MetricOptions): cloudwatch.IMetric {
+  public metricFailures(options: cloudwatch.MetricOptions): cloudwatch.Metric {
     return new cloudwatch.Metric({
       namespace: METRIC_NAMESPACE,
       metricName: FAILURE_METRIC_NAME,
@@ -487,7 +487,7 @@ export class Pipeline extends Construct {
   /**
    * The metrics that track failure of each action within the pipeline.
    */
-  public metricActionFailures(options: cloudwatch.MetricOptions): cloudwatch.IMetric[] {
+  public metricActionFailures(options: cloudwatch.MetricOptions): cloudwatch.Metric[] {
     return flatMap(this.pipeline.stages, stage => stage.actions.map(action => {
       return new cloudwatch.Metric({
         namespace: METRIC_NAMESPACE,

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -71,3 +71,11 @@ export function mapValues<T, U>(xs: {[key: string]: T}, fn: (x: T) => U): {[key:
   }
   return ret;
 }
+
+export function flatMap<T, U>(xs: T[], fn: (x: T) => U[]): U[] {
+  const ret = new Array<U>();
+  for (const x of xs) {
+    ret.push(...fn(x));
+  }
+  return ret;
+}


### PR DESCRIPTION
This extends the new pipeline failure metric approach introduced in #696,
by adding convenience methods to expose pipeline failure metrics at the per-
action level.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
