### PR TITLE
chore: change-control-lambda migrated to `NodeJsFunction`

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,3 +824,4 @@ of this library.
 ## License
 
 This library is licensed under the Apache 2.0 License.
+


### PR DESCRIPTION
The projen migration [PR](https://github.com/cdklabs/aws-delivlib/pull/841) introduced a breaking change.

Unfortunately when I merged the PR manually I removed the breaking change notice by accident.

This is just a dummy PR to re-introduce the notice so that `standard-version` performs a major version bump when the next release happens.

BREAKING CHANGE: `esbuild` or `docker` is required in order to bundle the change-control-lambda

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.