### PR TITLE
chore(integ tests): update message with integ test update command

### DIFF
--- a/lib/__tests__/run-test.sh
+++ b/lib/__tests__/run-test.sh
@@ -30,6 +30,6 @@ fi
 
 diff ${actual} ${expected} || {
   echo "Expected test stack template does not match synthesized output"
-  echo "To update expectations: 'npm test update'"
+  echo "To update expectations: 'npx projen integ:update'"
   exit 1
 }

--- a/lib/__tests__/run-test.sh
+++ b/lib/__tests__/run-test.sh
@@ -30,6 +30,6 @@ fi
 
 diff ${actual} ${expected} || {
   echo "Expected test stack template does not match synthesized output"
-  echo "To update expectations: 'npx projen integ:update'"
+  echo "To update expectations: 'yarn integ:update'"
   exit 1
 }


### PR DESCRIPTION
When integration test expected files get out of date, the command in the error message should work to run the integration tests. 

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.