### PR TITLE
chore: set package.json version to 0.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   ],
   "main": "lib/index.js",
   "license": "Apache-2.0",
-  "version": "13.0.34",
+  "version": "0.0.0",
   "jest": {
     "testMatch": [
       "**/lib/__tests__/**/?(*.)+(spec|test).js?(x)"


### PR DESCRIPTION
projen publishing (see #1033) uses GitHub releases/tags to track versions, and
doesn't use the version in package.json. The release is currently failing
because this version is still being set here.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.