### PR TITLE
chore: fix package.sh for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,3 +56,24 @@ jobs:
           dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release_npm:
+    name: Publish to npm
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: needs.release.outputs.latest_commit == github.sha
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - name: Release
+        run: npx -p jsii-release@latest jsii-release-npm
+        env:
+          NPM_DIST_TAG: latest
+          NPM_REGISTRY: registry.npmjs.org
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    container:
+      image: jsii/superchain

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -143,6 +143,22 @@
         }
       ]
     },
+    "publish:npm": {
+      "name": "publish:npm",
+      "description": "Publish this package to npm",
+      "env": {
+        "NPM_DIST_TAG": "latest",
+        "NPM_REGISTRY": "registry.npmjs.org"
+      },
+      "requiredEnv": [
+        "NPM_TOKEN"
+      ],
+      "steps": [
+        {
+          "exec": "npx -p jsii-release@latest jsii-release-npm"
+        }
+      ]
+    },
     "upgrade": {
       "name": "upgrade",
       "description": "upgrade dependencies",
@@ -186,7 +202,13 @@
       "description": "Create an npm tarball",
       "steps": [
         {
-          "exec": "/bin/bash ./package.sh"
+          "exec": "mkdir -p dist/js"
+        },
+        {
+          "exec": "yarn pack"
+        },
+        {
+          "exec": "mv *.tgz dist/js/"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -68,7 +68,4 @@ compileCustomResourceHandlers.exec('/bin/bash ./build-custom-resource-handlers.s
 
 project.compileTask.prependSpawn(compileCustomResourceHandlers);
 
-project.packageTask.reset();
-project.packageTask.exec('/bin/bash ./package.sh');
-
 project.synth();

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -43,6 +43,8 @@ const project = new TypeScriptProject({
     secret: 'GITHUB_TOKEN',
   },
   autoApproveUpgrades: true,
+
+  releaseToNpm: true,
 });
 
 // trick projen so that it doesn't override the version in package.json

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "bump": "npx projen bump",
     "unbump": "npx projen unbump",
     "publish:github": "npx projen publish:github",
+    "publish:npm": "npx projen publish:npm",
     "upgrade": "npx projen upgrade",
     "default": "npx projen default",
     "watch": "npx projen watch",

--- a/package.sh
+++ b/package.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-tarball=$(npm pack)
-mkdir -p dist/js
-mv ${tarball} dist/js/

--- a/package.sh
+++ b/package.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 tarball=$(npm pack)
-rm -fr dist
 mkdir -p dist/js
 mv ${tarball} dist/js/
-
-


### PR DESCRIPTION
The `release` and `bump` tasks write to `dist/changelog.md` and
`dist/version.txt`. Unfortunately, the `publish.sh` script that delivlib
uses removes the `dist` directory before copying over the artifacts. This caused
the release to fail.

Also, explicitly enable publishing to npm


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.