### PR TITLE
feat: make NuGet publisher support yum AND apt-based distributions

### DIFF
--- a/lib/__tests__/expected.yml
+++ b/lib/__tests__/expected.yml
@@ -2834,7 +2834,7 @@ Resources:
             Value: cdk-hnb659fds-assets-712950704752-us-east-1
           - Name: SCRIPT_S3_KEY
             Type: PLAINTEXT
-            Value: 053efa861f4bb4811cc7443590a600671935ff19eab190a9b040736f3cf756b9.zip
+            Value: b331bddd4fcb3d1d466ddd4c30728608b3a013016e6ed325e4b11d73b7b8cf57.zip
           - Name: FOR_REAL
             Type: PLAINTEXT
             Value: "true"

--- a/lib/publishing/nuget/publish.sh
+++ b/lib/publishing/nuget/publish.sh
@@ -2,7 +2,14 @@
 set -euo pipefail
 
 echo "Installing required CLI tools: jq, openssl..."
-yum install -y jq openssl
+if command -v yum &>/dev/null; then
+    yum install -y jq openssl
+elif command -v apt-get &>/dev/null; then
+    apt-get update
+    apt-get install -y jq openssl
+else
+    echo "!!! Neither an apt nor yum distribution - could not install jq and openssl, things might break!"
+fi
 
 if [[ "${FOR_REAL:-}" == "true" ]]; then
     dotnet=dotnet


### PR DESCRIPTION
The new superchain images are based on debian, so we cannot use yum to
install openssl and jq. Detect whether yum or apt-get is installed, and
issue the correct commands. Display a warning if neither of the tools is
found.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.