### PR TITLE
feat: support release notes for GitHub publishing

### DIFF
--- a/lib/__tests__/expected.yml
+++ b/lib/__tests__/expected.yml
@@ -3268,13 +3268,16 @@ Resources:
             Value: cdk-hnb659fds-assets-712950704752-us-east-1
           - Name: SCRIPT_S3_KEY
             Type: PLAINTEXT
-            Value: 8052fca741da226259577a0857de974eff37334424d24ba483890caa366a6045.zip
+            Value: 168799fb36a5c07de842b73d47e38fc33983aadeec36fca33b73cdc9388dce6a.zip
           - Name: BUILD_MANIFEST
             Type: PLAINTEXT
             Value: ./build.json
           - Name: CHANGELOG
             Type: PLAINTEXT
             Value: ./CHANGELOG.md
+          - Name: RELEASE_NOTES
+            Type: PLAINTEXT
+            Value: ./RELEASE_NOTES.md
           - Name: SIGNING_KEY_ARN
             Type: PLAINTEXT
             Value:

--- a/lib/publishing/github/create-release.js
+++ b/lib/publishing/github/create-release.js
@@ -12,6 +12,7 @@ if (!process.env.GITHUB_OWNER) { throw new Error('GITHUB_OWNER is required'); }
 
 const build_manifest = process.env.BUILD_MANIFEST || './build.json';
 const changelog_file = process.env.CHANGELOG || './CHANGELOG.md';
+const release_notes_file = process.env.RELEASE_NOTES || './RELEASE_NOTES.md';
 
 const client = github.client(process.env.GITHUB_TOKEN);
 
@@ -29,6 +30,14 @@ async function release_exists(repository, tag_name) {
             return ok(false);
         });
     });
+}
+
+async function read_release_notes() {
+    if (!await exists(release_notes_file)) {
+        return undefined;
+    }
+
+    return fs.readFile(release_notes_file, 'utf8');
 }
 
 async function read_changelog(version) {
@@ -101,11 +110,16 @@ async function main() {
         return;
     }
 
-    console.log('reading changelog...');
-    const changelog = await read_changelog(manifest.version);
+    console.log('reading release notes...');
+    let release_notes = await read_release_notes();
+
+    if (!release_notes) {
+        console.log('reading changelog...');
+        release_notes = await read_changelog(manifest.version);
+    }
 
     console.log('creating release...');
-    const release_id = await create_release(repository, tag_name, commit, changelog);
+    const release_id = await create_release(repository, tag_name, commit, release_notes);
 
     console.log('uploading assets...');
     await upload_assets(repository, release_id, process.argv.slice(2));


### PR DESCRIPTION
Currently, the GitHub publishing job looks for a CHANGELOG file (either in a
default location or set by environment variable), parses the changelog for the
current version, and uses that result as the release notes. This change enables
an alternative approach; creating a RELEASE_NOTES file which contains the
complete release notes, ready for publishing.

The advantage of this new approach might be if you want to do some
post-processing formatting on the changelog (or even include extra notes not
normally present in the default changelog). For CDKv2, this will be used to
combine the changelog entries for the stable release (aws-cdk-lib) and for the
alpha modules.

related https://github.com/aws/aws-cdk/issues/16802

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.