### PR TITLE
fix(ecr-mirror): allow using the same directory twice as MirrorSource

### DIFF
--- a/lib/__tests__/registry-sync/mirror-source.test.ts
+++ b/lib/__tests__/registry-sync/mirror-source.test.ts
@@ -199,5 +199,24 @@ describe('RegistryImageSource', () => {
       const expected = 'docker build --pull -t myregistry/myrepository:latest --build-arg arg1=val1 --build-arg arg2=val2 myrepository';
       expect(result.commands[2]).toEqual(expected);
     });
+
+    test('can bind the same directory twice if they have different build args', () => {
+      // GIVEN
+      const stack = new Stack();
+      const ecrRegistry = 'myregistry';
+      const source1 = MirrorSource.fromDir(path.join(__dirname, 'docker-asset'), 'myrepository');
+      const source2 = MirrorSource.fromDir(path.join(__dirname, 'docker-asset'), 'myrepository', {
+        buildArgs: {
+          arg1: 'val1',
+          arg2: 'val2',
+        },
+      });
+
+      // WHEN
+      source1.bind({ scope: stack, ecrRegistry });
+      source2.bind({ scope: stack, ecrRegistry });
+
+      // THEN -- didn't throw
+    });
   });
 });

--- a/lib/registry-sync/mirror-source.ts
+++ b/lib/registry-sync/mirror-source.ts
@@ -115,7 +115,7 @@ export abstract class MirrorSource {
       }
 
       public bind(options: MirrorSourceBindOptions) {
-        const asset = new s3Assets.Asset(options.scope, `BuildContext${this.directory}`, { path: this.directory! });
+        const asset = new s3Assets.Asset(options.scope, `BuildContext${this.directory}${JSON.stringify(opts.buildArgs ?? {})}`, { path: this.directory! });
         if (options.syncJob) {
           asset.grantRead(options.syncJob);
         }


### PR DESCRIPTION
As long as the build arguments are different.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.