### PR TITLE
fix(ecr-mirror): fromDir() fails when building multiple tags for one repo

### DIFF
--- a/lib/__tests__/registry-sync/mirror-source.test.ts
+++ b/lib/__tests__/registry-sync/mirror-source.test.ts
@@ -92,9 +92,9 @@ describe('RegistryImageSource', () => {
       // THEN
       expect(result.repositoryName).toEqual('myrepository');
       expect(result.tag).toEqual('latest');
-      const cmds = result.commands;
-      expect(cmds.shift()).toMatch(/aws s3 cp s3:.* myrepository.zip/);
-      expect(cmds).toEqual([
+      expect(result.commands).toEqual([
+        'rm -rf myrepository.zip myrepository',
+        expect.stringMatching(/aws s3 cp s3:.* myrepository.zip/),
         'unzip myrepository.zip -d myrepository',
         'docker build --pull -t myregistry/myrepository:latest myrepository',
       ]);
@@ -115,7 +115,12 @@ describe('RegistryImageSource', () => {
       // THEN
       expect(result.repositoryName).toEqual('myrepository');
       expect(result.tag).toEqual('mytag');
-      expect(result.commands[2]).toEqual('docker build --pull -t myregistry/myrepository:mytag myrepository');
+      expect(result.commands).toEqual([
+        'rm -rf myrepository.zip myrepository',
+        expect.stringMatching(/aws s3 cp s3:.* myrepository.zip/),
+        'unzip myrepository.zip -d myrepository',
+        'docker build --pull -t myregistry/myrepository:mytag myrepository',
+      ]);
     });
 
     test('syncJob is given permission to s3 asset', () => {
@@ -196,8 +201,12 @@ describe('RegistryImageSource', () => {
       });
 
       // THEN
-      const expected = 'docker build --pull -t myregistry/myrepository:latest --build-arg arg1=val1 --build-arg arg2=val2 myrepository';
-      expect(result.commands[2]).toEqual(expected);
+      expect(result.commands).toEqual([
+        'rm -rf myrepository.zip myrepository',
+        expect.stringMatching(/aws s3 cp s3:.* myrepository.zip/),
+        'unzip myrepository.zip -d myrepository',
+        'docker build --pull -t myregistry/myrepository:latest --build-arg arg1=val1 --build-arg arg2=val2 myrepository',
+      ]);
     });
 
     test('can bind the same directory twice if they have different build args', () => {

--- a/lib/registry-sync/mirror-source.ts
+++ b/lib/registry-sync/mirror-source.ts
@@ -128,11 +128,15 @@ export abstract class MirrorSource {
           Object.entries(opts.buildArgs).forEach(([k, v]) => cmdFlags.push('--build-arg', `${k}=${v}`));
         }
 
+        const zipFile = `${this.repositoryName}.zip`;
+        const tmpDir = this.repositoryName;
+
         return {
           commands: [
-            `aws s3 cp ${asset.s3ObjectUrl} ${this.repositoryName}.zip`,
-            `unzip ${this.repositoryName}.zip -d ${this.repositoryName}`,
-            `docker build ${cmdFlags.join(' ')} ${this.repositoryName}`,
+            `rm -rf ${zipFile} ${tmpDir}`,
+            `aws s3 cp ${asset.s3ObjectUrl} ${zipFile}`,
+            `unzip ${zipFile} -d ${tmpDir}`,
+            `docker build ${cmdFlags.join(' ')} ${tmpDir}`,
           ],
           repositoryName: this.repositoryName,
           tag: this.tag,


### PR DESCRIPTION
The `unzip` command used will throw up an `overwrite? [y]es/[n]o` dialog
when using `fromDir()` to build multiple tags into the same repository.

This fails. Prevent it by cleaning similarly named files and directories
before we begin.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.