### PR TITLE
fix(s3): S3 publisher incorrectly skips prefix releases

### DIFF
--- a/lib/publishing/s3/publish.sh
+++ b/lib/publishing/s3/publish.sh
@@ -27,7 +27,8 @@ fi
 if [[ "${idempotency_token:-}" != "" ]]; then
     echo "Idempotency token: $idempotency_token"
 
-    aws s3 ls $BUCKET_URL/$idempotency_token > /dev/null && {
+    # Must use 's3 cp' to try and read exact filename. 's3 ls' would match prefixes as well.
+    aws s3 cp $BUCKET_URL/$idempotency_token - > /dev/null 2>&1 && {
         echo "Token found, stopping."
         exit 0
     } || {


### PR DESCRIPTION
The S3 publisher uses a signaling file in the target bucket to show
that a particular release has already been uploaded, and it should
skip uploading any of the files in the current distribution.

However, it used `aws s3 ls` to do that, which matches prefixes.

So if we previously uploaded `xyz-1.2.3-pre`, and are now trying to
upload `xyz-1.2.3`, it will incorrectly skip the new upload.

Switch to using `aws s3 cp` to fix this.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.