### PR TITLE
chore: wrong auto approve username

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       pull-requests: write
     if: contains(github.event.pull_request.labels.*.name, 'auto-approve') &&
-      (github.event.pull_request.user.login == 'aws-cdk-automation')
+      (github.event.pull_request.user.login == 'cdklabs-automation')
     steps:
       - uses: hmarr/auto-approve-action@v2.1.0
         with:

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -39,7 +39,7 @@ const project = new TypeScriptProject({
 
   pullRequestTemplate: false,
   autoApproveOptions: {
-    allowedUsernames: ['aws-cdk-automation'],
+    allowedUsernames: ['cdklabs-automation'],
     secret: 'GITHUB_TOKEN',
   },
   autoApproveUpgrades: true,


### PR DESCRIPTION
I think we just didn't change this from when before we had the `cdklabs-automation` user, which is the one creating the upgrade PR's.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.