### PR TITLE
feat: upgrade to cdk v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      checks: write
       contents: write
-      actions: write
+    outputs:
+      self_mutation_commit: ${{ steps.self_mutation.outputs.self_mutation_commit }}
     env:
       CI: "true"
     steps:
@@ -21,28 +21,43 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Set git identity
         run: |-
+          git config --global init.defaultBranch main
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
+      - name: Setup Node.js
+        uses: actions/setup-node@v2.2.0
+        with:
+          node-version: 14.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: build
         run: npx projen build
-      - name: Check for changes
-        id: git_diff
-        run: git diff --exit-code || echo "::set-output name=has_changes::true"
-      - if: steps.git_diff.outputs.has_changes
-        name: Commit and push changes (if changed)
-        run: 'git add . && git commit -m "chore: self mutation" && git push origin
-          HEAD:${{ github.event.pull_request.head.ref }}'
-      - if: steps.git_diff.outputs.has_changes
-        name: Update status check (if changed)
+      - name: Self mutation
+        id: self_mutation
+        run: |-
+          if ! git diff --exit-code; then
+            git add .
+            git commit -m "chore: self mutation"
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+            echo "::set-output name=self_mutation_commit::$(git rev-parse HEAD)"
+          fi
+  update-status:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      actions: write
+    if: ${{ needs.build.outputs.self_mutation_commit }}
+    steps:
+      - name: Update status check (if changed)
         run: gh api -X POST /repos/${{ github.event.pull_request.head.repo.full_name
-          }}/check-runs -F name="build" -F head_sha="$(git rev-parse HEAD)" -F
-          status="completed" -F conclusion="success"
+          }}/check-runs -F name="build" -F head_sha="${{
+          needs.build.outputs.self_mutation_commit }}" -F status="completed" -F
+          conclusion="success"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - if: steps.git_diff.outputs.has_changes
-        name: Cancel workflow (if changed)
+      - name: Cancel workflow (if changed)
         run: gh api -X POST /repos/${{ github.event.pull_request.head.repo.full_name
           }}/actions/runs/${{ github.run_id }}/cancel
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,13 @@ jobs:
           fetch-depth: 0
       - name: Set git identity
         run: |-
+          git config --global init.defaultBranch main
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
+      - name: Setup Node.js
+        uses: actions/setup-node@v2.2.0
+        with:
+          node-version: 14.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -46,6 +51,9 @@ jobs:
       contents: write
     if: needs.release.outputs.latest_commit == github.sha
     steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
@@ -69,6 +77,9 @@ jobs:
       contents: read
     if: needs.release.outputs.latest_commit == github.sha
     steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
@@ -80,5 +91,3 @@ jobs:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-    container:
-      image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -20,8 +20,13 @@ jobs:
           ref: main
       - name: Set git identity
         run: |-
+          git config --global init.defaultBranch main
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
+      - name: Setup Node.js
+        uses: actions/setup-node@v2.2.0
+        with:
+          node-version: 14.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -54,6 +59,7 @@ jobs:
           ref: main
       - name: Set git identity
         run: |-
+          git config --global init.defaultBranch main
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
       - name: Download patch

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ junit.xml
 /dist/
 !/.projen/jest-snapshot-resolver.js
 !/.eslintrc.json
-/assets/
 cdk.out
 pipeline/*.js
 pipeline/*.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ junit.xml
 /dist/
 !/.projen/jest-snapshot-resolver.js
 !/.eslintrc.json
+/assets/
 cdk.out
 pipeline/*.js
 pipeline/*.d.ts

--- a/.npmignore
+++ b/.npmignore
@@ -19,4 +19,3 @@ dist
 tsconfig.tsbuildinfo
 /lib/__tests__/
 /.eslintrc.json
-!/assets/

--- a/.npmignore
+++ b/.npmignore
@@ -19,3 +19,4 @@ dist
 tsconfig.tsbuildinfo
 /lib/__tests__/
 /.eslintrc.json
+!/assets/

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -1,10 +1,6 @@
 {
   "dependencies": [
     {
-      "name": "@monocdk-experiment/assert",
-      "type": "build"
-    },
-    {
       "name": "@types/aws-lambda",
       "type": "build"
     },
@@ -14,7 +10,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^14.17.0",
+      "version": "^14",
       "type": "build"
     },
     {
@@ -29,6 +25,10 @@
     },
     {
       "name": "aws-cdk",
+      "type": "build"
+    },
+    {
+      "name": "aws-cdk-lib",
       "type": "build"
     },
     {
@@ -78,10 +78,6 @@
       "type": "build"
     },
     {
-      "name": "monocdk",
-      "type": "build"
-    },
-    {
       "name": "node-ical",
       "type": "build"
     },
@@ -112,11 +108,11 @@
       "type": "build"
     },
     {
-      "name": "constructs",
+      "name": "aws-cdk-lib",
       "type": "peer"
     },
     {
-      "name": "monocdk",
+      "name": "constructs",
       "type": "peer"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -40,6 +40,33 @@
       ],
       "condition": "! git log --oneline -1 | grep -q \"chore(release):\""
     },
+    "bundle": {
+      "name": "bundle",
+      "description": "Prepare assets",
+      "steps": [
+        {
+          "spawn": "bundle:lib/chime-notifier/handler/notifier-handler"
+        }
+      ]
+    },
+    "bundle:lib/chime-notifier/handler/notifier-handler": {
+      "name": "bundle:lib/chime-notifier/handler/notifier-handler",
+      "description": "Create a JavaScript bundle from lib/chime-notifier/handler/notifier-handler.ts",
+      "steps": [
+        {
+          "exec": "esbuild --bundle lib/chime-notifier/handler/notifier-handler.ts --target=\"node14\" --platform=\"node\" --outfile=\"assets/lib/chime-notifier/handler/notifier-handler/index.js\" --external:aws-sdk"
+        }
+      ]
+    },
+    "bundle:lib/chime-notifier/handler/notifier-handler:watch": {
+      "name": "bundle:lib/chime-notifier/handler/notifier-handler:watch",
+      "description": "Continuously update the JavaScript bundle from lib/chime-notifier/handler/notifier-handler.ts",
+      "steps": [
+        {
+          "exec": "esbuild --bundle lib/chime-notifier/handler/notifier-handler.ts --target=\"node14\" --platform=\"node\" --outfile=\"assets/lib/chime-notifier/handler/notifier-handler/index.js\" --external:aws-sdk --watch"
+        }
+      ]
+    },
     "clobber": {
       "name": "clobber",
       "description": "hard resets to HEAD of origin and cleans the local repo",
@@ -134,10 +161,7 @@
           "exec": "mkdir -p dist/js"
         },
         {
-          "exec": "yarn pack"
-        },
-        {
-          "exec": "mv *.tgz dist/js/"
+          "exec": "mv $(npm pack) dist/js/"
         }
       ]
     },
@@ -147,7 +171,12 @@
     },
     "pre-compile": {
       "name": "pre-compile",
-      "description": "Prepare the project for compilation"
+      "description": "Prepare the project for compilation",
+      "steps": [
+        {
+          "spawn": "bundle"
+        }
+      ]
     },
     "release": {
       "name": "release",
@@ -178,7 +207,7 @@
       "description": "Run tests",
       "steps": [
         {
-          "exec": "jest --passWithNoTests --all --updateSnapshot"
+          "exec": "jest --passWithNoTests --all --updateSnapshot --coverageProvider=v8"
         },
         {
           "spawn": "eslint"

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -40,33 +40,6 @@
       ],
       "condition": "! git log --oneline -1 | grep -q \"chore(release):\""
     },
-    "bundle": {
-      "name": "bundle",
-      "description": "Prepare assets",
-      "steps": [
-        {
-          "spawn": "bundle:lib/chime-notifier/handler/notifier-handler"
-        }
-      ]
-    },
-    "bundle:lib/chime-notifier/handler/notifier-handler": {
-      "name": "bundle:lib/chime-notifier/handler/notifier-handler",
-      "description": "Create a JavaScript bundle from lib/chime-notifier/handler/notifier-handler.ts",
-      "steps": [
-        {
-          "exec": "esbuild --bundle lib/chime-notifier/handler/notifier-handler.ts --target=\"node14\" --platform=\"node\" --outfile=\"assets/lib/chime-notifier/handler/notifier-handler/index.js\" --external:aws-sdk"
-        }
-      ]
-    },
-    "bundle:lib/chime-notifier/handler/notifier-handler:watch": {
-      "name": "bundle:lib/chime-notifier/handler/notifier-handler:watch",
-      "description": "Continuously update the JavaScript bundle from lib/chime-notifier/handler/notifier-handler.ts",
-      "steps": [
-        {
-          "exec": "esbuild --bundle lib/chime-notifier/handler/notifier-handler.ts --target=\"node14\" --platform=\"node\" --outfile=\"assets/lib/chime-notifier/handler/notifier-handler/index.js\" --external:aws-sdk --watch"
-        }
-      ]
-    },
     "clobber": {
       "name": "clobber",
       "description": "hard resets to HEAD of origin and cleans the local repo",
@@ -171,12 +144,7 @@
     },
     "pre-compile": {
       "name": "pre-compile",
-      "description": "Prepare the project for compilation",
-      "steps": [
-        {
-          "spawn": "bundle"
-        }
-      ]
+      "description": "Prepare the project for compilation"
     },
     "release": {
       "name": "release",

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,6 +1,6 @@
-const { typescript: { TypeScriptProject } } = require('projen');
+const { typescript, javascript } = require('projen');
 
-const project = new TypeScriptProject({
+const project = new typescript.TypeScriptProject({
   name: 'aws-delivlib',
   description: 'A fabulous library for defining continuous pipelines for building, testing and releasing code libraries.',
   repository: 'https://github.com/cdklabs/aws-delivlib.git',
@@ -8,6 +8,7 @@ const project = new TypeScriptProject({
   projenUpgradeSecret: 'PROJEN_GITHUB_TOKEN',
   authorName: 'Amazon Web Services',
   authorUrl: 'https://aws.amazon.com',
+  minNodeVersion: '14.17.0',
   keywords: [
     'aws-cdk',
     'continuous-delivery',
@@ -16,12 +17,11 @@ const project = new TypeScriptProject({
   ],
   deps: ['changelog-parser'],
   devDeps: [
-    '@monocdk-experiment/assert',
     '@types/aws-lambda',
     'aws-cdk',
     'jest-create-mock-instance',
     'constructs',
-    'monocdk',
+    'aws-cdk-lib',
     'standard-version',
     'ts-jest',
     'typescript',
@@ -32,7 +32,7 @@ const project = new TypeScriptProject({
   ],
   peerDeps: [
     'constructs',
-    'monocdk',
+    'aws-cdk-lib',
   ],
   srcdir: 'lib',
   testdir: 'lib/__tests__',
@@ -49,6 +49,15 @@ const project = new TypeScriptProject({
 
 // trick projen so that it doesn't override the version in package.json
 project.tasks.addEnvironment('RELEASE', '1');
+const bundler = javascript.Bundler.of(project);
+if (!bundler) {
+  throw new Error('No bundler found. Please add a Bundler component to your project.');
+}
+bundler.addBundle('lib/chime-notifier/handler/notifier-handler.ts', {
+  externals: ['aws-sdk'],
+  target: 'node14',
+  platform: 'node',
+});
 
 project.gitignore.exclude('cdk.out');
 project.gitignore.exclude('pipeline/*.js');

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -49,15 +49,6 @@ const project = new typescript.TypeScriptProject({
 
 // trick projen so that it doesn't override the version in package.json
 project.tasks.addEnvironment('RELEASE', '1');
-const bundler = javascript.Bundler.of(project);
-if (!bundler) {
-  throw new Error('No bundler found. Please add a Bundler component to your project.');
-}
-bundler.addBundle('lib/chime-notifier/handler/notifier-handler.ts', {
-  externals: ['aws-sdk'],
-  target: 'node14',
-  platform: 'node',
-});
 
 project.gitignore.exclude('cdk.out');
 project.gitignore.exclude('pipeline/*.js');

--- a/lib/__tests__/auto-build.test.ts
+++ b/lib/__tests__/auto-build.test.ts
@@ -1,5 +1,5 @@
-import '@monocdk-experiment/assert/jest';
-import { App, Stack } from 'monocdk';
+import { App, Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 import { AutoBuild, GitHubRepo } from '../../lib';
 
 let app: App;
@@ -16,8 +16,9 @@ test('webhooks are enabled by default', () => {
       tokenSecretArn: 'arn:aws:secretsmanager:someregion:someaccount:secret:sometoken',
     }),
   });
+  const template = Template.fromStack(stack);
 
-  expect(stack).toHaveResource('AWS::CodeBuild::Project', {
+  template.hasResourceProperties('AWS::CodeBuild::Project', {
     Triggers: {
       FilterGroups: [
         [
@@ -40,8 +41,9 @@ test('webhooks for a single branch', () => {
     }),
     branch: 'banana',
   });
+  const template = Template.fromStack(stack);
 
-  expect(stack).toHaveResource('AWS::CodeBuild::Project', {
+  template.hasResourceProperties('AWS::CodeBuild::Project', {
     Triggers: {
       FilterGroups: [
         [
@@ -78,8 +80,9 @@ test('webhooks for multiple branches', () => {
     }),
     branches: ['banana', 'grapefruit'],
   });
+  const template = Template.fromStack(stack);
 
-  expect(stack).toHaveResource('AWS::CodeBuild::Project', {
+  template.hasResourceProperties('AWS::CodeBuild::Project', {
     Triggers: {
       FilterGroups: [
         [
@@ -116,8 +119,9 @@ test('can disable webhooks', () => {
     }),
     webhook: false,
   });
+  const template = Template.fromStack(stack);
 
-  expect(stack).toHaveResource('AWS::CodeBuild::Project', {
+  template.hasResourceProperties('AWS::CodeBuild::Project', {
     Triggers: {
       Webhook: false,
     },

--- a/lib/__tests__/bump.test.ts
+++ b/lib/__tests__/bump.test.ts
@@ -1,7 +1,7 @@
 // tslint:disable: max-line-length
-import * as cdk from 'monocdk';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 import { AutoBump, WritableGitHubRepo } from '../../lib';
-import '@monocdk-experiment/assert/jest';
 
 const Stack = cdk.Stack;
 
@@ -21,11 +21,12 @@ test('autoBump', () => {
   new AutoBump(stack, 'MyAutoBump', {
     repo: MOCK_REPO,
   });
+  const template = Template.fromStack(stack);
 
   // THEN
 
   // build project
-  expect(stack).toHaveResource('AWS::CodeBuild::Project', {
+  template.hasResourceProperties('AWS::CodeBuild::Project', {
     Triggers: {
       Webhook: false,
     },
@@ -77,9 +78,10 @@ test('autoBump with schedule', () => {
     repo: MOCK_REPO,
     scheduleExpression: 'cron(0 12 * * ? *)',
   });
+  const template = Template.fromStack(stack);
 
   // default schedule
-  expect(stack).toHaveResource('AWS::Events::Rule', {
+  template.hasResourceProperties('AWS::Events::Rule', {
     ScheduleExpression: 'cron(0 12 * * ? *)',
   });
 
@@ -94,11 +96,12 @@ test('autoBump with custom cloneDepth', () => {
     repo: MOCK_REPO,
     cloneDepth: 10,
   });
+  const template = Template.fromStack(stack);
 
   // THEN
 
   // build project
-  expect(stack).toHaveResource('AWS::CodeBuild::Project', {
+  template.hasResourceProperties('AWS::CodeBuild::Project', {
     Triggers: {
       Webhook: false,
     },
@@ -149,10 +152,11 @@ test('autoBump with schedule disabled', () => {
     repo: MOCK_REPO,
     scheduleExpression: 'disable',
   });
+  const template = Template.fromStack(stack);
 
   // THEN
-  expect(stack).not.toHaveResource('AWS::Events::Rule', {
-    ScheduleExpression: 'cron(0 12 * * ? *)',
+  template.hasResourceProperties('AWS::Events::Rule', {
+    ScheduleExpression: 'disable',
   });
 });
 
@@ -172,11 +176,12 @@ test('autoBump with push only', () => {
     repo,
     pushOnly: true,
   });
+  const template = Template.fromStack(stack);
 
   // THEN
 
   // build project
-  expect(stack).toHaveResource('AWS::CodeBuild::Project', {
+  template.hasResourceProperties('AWS::CodeBuild::Project', {
     Triggers: {
       Webhook: false,
     },
@@ -230,11 +235,12 @@ test('autoBump with pull request with custom options', () => {
     },
 
   });
+  const template = Template.fromStack(stack);
 
   // THEN
 
   // build project
-  expect(stack).toHaveResource('AWS::CodeBuild::Project', {
+  template.hasResourceProperties('AWS::CodeBuild::Project', {
     Triggers: {
       Webhook: false,
     },

--- a/lib/__tests__/change-control-lambda/disable-transition.test.ts
+++ b/lib/__tests__/change-control-lambda/disable-transition.test.ts
@@ -12,10 +12,16 @@ const mockEnableStageTransition = jest.fn((_params: AWS.CodePipeline.EnableStage
 const pipelineName = 'MyPipeline';
 const stageName = 'MyStage';
 
-(AWS as any).CodePipeline = jest.fn(() => ({
-  disableStageTransition: mockDisableStageTransition,
-  enableStageTransition: mockEnableStageTransition,
-}) as unknown as AWS.CodePipeline).mockName('AWS.CodePipeline') as any;
+jest.mock('aws-sdk', () => {
+  return {
+    CodePipeline: jest.fn(() => {
+      return {
+        disableStageTransition: mockDisableStageTransition,
+        enableStageTransition: mockEnableStageTransition,
+      };
+    }),
+  };
+});
 
 describe('disableTransition', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/lib/__tests__/change-control-lambda/handler.test.ts
+++ b/lib/__tests__/change-control-lambda/handler.test.ts
@@ -1,9 +1,5 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import AWS = require('aws-sdk');
 import * as transitions from '../../change-control-lambda/disable-transition';
 import * as timeWindow from '../../change-control-lambda/time-window';
-
-// tslint:disable:no-console
 
 // _____                                _   _
 // |  __ \                              | | (_)
@@ -14,12 +10,22 @@ import * as timeWindow from '../../change-control-lambda/time-window';
 //                | |
 //                |_|
 
-jest.mock('aws-sdk');
+jest.mock('aws-sdk', () => {
+  return {
+    S3: jest.fn(() => {
+      return {
+        getObject: mockGetObject,
+      };
+    }).mockName('AWS.S3'),
+    CodePipeline: jest.fn(() => {
+      return {};
+    }).mockName('AWS.CodePipeline'),
+  };
+});
 jest.mock('../../change-control-lambda/disable-transition');
 jest.mock('../../change-control-lambda/time-window');
 
 const mockGetObject = jest.fn().mockName('AWS.S3.getObject');
-(AWS as any).S3 = jest.fn(() => ({ getObject: mockGetObject })).mockName('AWS.S3') as any;
 
 const mockEnableTransition =
   jest.fn((_pipeline: string, _stage: string) => Promise.resolve(undefined))

--- a/lib/__tests__/chime-notifier.test.ts
+++ b/lib/__tests__/chime-notifier.test.ts
@@ -7,7 +7,6 @@ import {
 import { Template } from 'aws-cdk-lib/assertions';
 import { Construct } from 'constructs';
 import { ChimeNotifier } from '../../lib';
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 import { codePipeline, handler } from '../../lib/chime-notifier/handler/notifier-handler';
 
 jest.mock('https', () => {
@@ -150,7 +149,7 @@ export class FakeSourceAction extends aws_codepipeline_actions.Action {
   // tslint:disable-next-line: max-line-length
   protected bound(_scope: Construct, _stage: aws_codepipeline.IStage, _options: aws_codepipeline.ActionBindOptions): aws_codepipeline.ActionConfig {
     return {
-      configuration: {},
+      configuration: { },
     };
   }
 }

--- a/lib/__tests__/code-signing-cert.test.ts
+++ b/lib/__tests__/code-signing-cert.test.ts
@@ -42,7 +42,7 @@ test('secret name consists of stack name and relative construct path', () => {
   // THEN - specifically: does not include construct names above the containing stack
   // uses the actual stack name (and not the stack NODE name)
   template.hasResourceProperties('Custom::RsaPrivateKeySecret', {
-    secretName: 'ActualStackName/Inbetween/Cert/RSAPrivateKey',
+    SecretName: 'ActualStackName/Inbetween/Cert/RSAPrivateKey',
   });
 });
 
@@ -59,6 +59,6 @@ test('secret name can be overridden', () => {
   const template = Template.fromStack(stack);
 
   template.hasResourceProperties('Custom::RsaPrivateKeySecret', {
-    secretName: 'Sekrit/RSAPrivateKey',
+    SecretName: 'Sekrit/RSAPrivateKey',
   });
 });

--- a/lib/__tests__/code-signing-cert.test.ts
+++ b/lib/__tests__/code-signing-cert.test.ts
@@ -1,8 +1,9 @@
 import {
-  App, Construct, Stack,
+  App, Stack,
   aws_kms as kms,
-} from 'monocdk';
-import '@monocdk-experiment/assert/jest';
+} from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { Construct } from 'constructs';
 import * as delivlib from '../../lib';
 
 
@@ -36,11 +37,12 @@ test('secret name consists of stack name and relative construct path', () => {
     pemCertificate: 'asdf',
     secretEncryptionKey: key,
   });
+  const template = Template.fromStack(stack);
 
   // THEN - specifically: does not include construct names above the containing stack
   // uses the actual stack name (and not the stack NODE name)
-  expect(stack).toHaveResource('Custom::RsaPrivateKeySecret', {
-    SecretName: 'ActualStackName/Inbetween/Cert/RSAPrivateKey',
+  template.hasResourceProperties('Custom::RsaPrivateKeySecret', {
+    secretName: 'ActualStackName/Inbetween/Cert/RSAPrivateKey',
   });
 });
 
@@ -54,8 +56,9 @@ test('secret name can be overridden', () => {
     secretEncryptionKey: key,
     baseName: 'Sekrit',
   });
+  const template = Template.fromStack(stack);
 
-  expect(stack).toHaveResource('Custom::RsaPrivateKeySecret', {
-    SecretName: 'Sekrit/RSAPrivateKey',
+  template.hasResourceProperties('Custom::RsaPrivateKeySecret', {
+    secretName: 'Sekrit/RSAPrivateKey',
   });
 });

--- a/lib/__tests__/integ.delivlib.ts
+++ b/lib/__tests__/integ.delivlib.ts
@@ -1,4 +1,4 @@
-import * as cdk from 'monocdk';
+import * as cdk from 'aws-cdk-lib';
 import { TestStack } from './test-stack';
 
 

--- a/lib/__tests__/open-pgp-key-pair.test.ts
+++ b/lib/__tests__/open-pgp-key-pair.test.ts
@@ -25,14 +25,14 @@ test('correctly creates', () => {
 
   // THEN
   template.hasResourceProperties('AWS::CloudFormation::CustomResource', Match.objectLike({
-    identity: 'Test',
-    email: 'nobody@nowhere.com',
-    expiry: '1d',
-    keySizeBits: 1024,
-    secretName: 'SecretName',
-    keyArn: stack.resolve(encryptionKey.keyArn),
-    version: 0,
-    deleteImmediately: false,
+    Identity: 'Test',
+    Email: 'nobody@nowhere.com',
+    Expiry: '1d',
+    KeySizeBits: 1024,
+    SecretName: 'SecretName',
+    KeyArn: stack.resolve(encryptionKey.keyArn),
+    Version: 0,
+    DeleteImmediately: false,
   }));
 });
 

--- a/lib/__tests__/pipeline-notifications/slack.test.ts
+++ b/lib/__tests__/pipeline-notifications/slack.test.ts
@@ -1,9 +1,9 @@
-import '@monocdk-experiment/assert/jest';
 import {
   App, Stack,
   aws_codecommit as codecommit,
   aws_chatbot as chatbot,
-} from 'monocdk';
+} from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 import { Pipeline, CodeCommitRepo, SlackNotification } from '../../../lib';
 
 describe('slack notifications', () => {
@@ -21,9 +21,10 @@ describe('slack notifications', () => {
 
     // WHEN
     pipe.notifyOnFailure(new SlackNotification({ channels: [slackChannel] }));
+    const template = Template.fromStack(stack);
 
     // THEN
-    expect(stack).toHaveResource('AWS::CodeStarNotifications::NotificationRule', {
+    template.hasResourceProperties('AWS::CodeStarNotifications::NotificationRule', {
       DetailType: 'BASIC',
       EventTypeIds: ['codepipeline-pipeline-action-execution-failed'],
       Name: {
@@ -67,9 +68,10 @@ describe('slack notifications', () => {
     // WHEN
     pipe.notifyOnFailure(new SlackNotification({ channels: [slackChannel1] }));
     pipe.notifyOnFailure(new SlackNotification({ channels: [slackChannel2] }));
+    const template = Template.fromStack(stack);
 
     // THEN
-    expect(stack).toHaveResource('AWS::CodeStarNotifications::NotificationRule', {
+    template.hasResourceProperties('AWS::CodeStarNotifications::NotificationRule', {
       Targets: [
         {
           TargetAddress: stack.resolve(slackChannel1.slackChannelConfigurationArn),
@@ -77,7 +79,7 @@ describe('slack notifications', () => {
         },
       ],
     });
-    expect(stack).toHaveResource('AWS::CodeStarNotifications::NotificationRule', {
+    template.hasResourceProperties('AWS::CodeStarNotifications::NotificationRule', {
       Targets: [
         {
           TargetAddress: stack.resolve(slackChannel2.slackChannelConfigurationArn),

--- a/lib/__tests__/pipeline.test.ts
+++ b/lib/__tests__/pipeline.test.ts
@@ -1,12 +1,13 @@
 import * as path from 'path';
-import { expect as cdk_expect, haveResource, haveResourceLike, SynthUtils, ABSENT } from '@monocdk-experiment/assert';
 import {
-  App, Construct, Duration, Stack,
+  App, Duration, Stack,
   aws_codebuild as codebuild,
   aws_codecommit as codecommit,
   aws_codepipeline as cpipeline,
   aws_codepipeline_actions as cpipeline_actions,
-} from 'monocdk';
+} from 'aws-cdk-lib';
+import { Capture, Template, Match } from 'aws-cdk-lib/assertions';
+import { Construct } from 'constructs';
 import * as delivlib from '../../lib';
 import { determineRunOrder } from '../../lib/util';
 
@@ -18,9 +19,11 @@ test('pipelineName can be used to set a physical name for the pipeline', async (
     pipelineName: 'HelloPipeline',
   });
 
-  cdk_expect(stack).to(haveResource('AWS::CodePipeline::Pipeline', {
+  const template = Template.fromStack(stack);
+
+  template.hasResourceProperties('AWS::CodePipeline::Pipeline', {
     Name: 'HelloPipeline',
-  }));
+  });
 });
 
 test('concurrency: unlimited by default', async () => {
@@ -58,7 +61,7 @@ test('determineRunOrder: creates groups of up to "concurrency" actions', async (
   testCase({ actionCount: 3, concurrency: 2 });
 
   function testCase({ actionCount, concurrency }: { actionCount: number; concurrency: number }) {
-    const actionsPerRunOrder: { [runOrder: number]: number } = { };
+    const actionsPerRunOrder: { [runOrder: number]: number } = {};
     for (let i = 0; i < actionCount; ++i) {
       const runOrder = determineRunOrder(i, concurrency)!;
       if (!actionsPerRunOrder[runOrder]) {
@@ -92,60 +95,61 @@ test('can add arbitrary shellables with different artifacts', () => {
   }).action;
 
   pipeline.addPublish(new Pub(stack, 'Pub'), { inputArtifact: action.actionProperties.outputs![0] });
+  const template = Template.fromStack(stack);
 
-  cdk_expect(stack).to(haveResourceLike('AWS::CodePipeline::Pipeline', {
-    Stages: [
+  template.hasResourceProperties('AWS::CodePipeline::Pipeline', {
+    Stages: Match.arrayWith([
       {
-        Name: 'Source',
         Actions: [
-          {
-            ActionTypeId: { Category: 'Source', Owner: 'AWS', Provider: 'CodeCommit' },
+          Match.objectLike({
+            ActionTypeId: { Category: 'Source', Owner: 'AWS', Provider: 'CodeCommit', Version: '1' },
             Name: 'Pull',
             OutputArtifacts: [
               {
                 Name: 'Source',
               },
             ],
-          },
+          }),
         ],
+        Name: 'Source',
       },
       {
-        Name: 'Build',
         Actions: [
-          {
+          Match.objectLike({
             Name: 'Build',
-            ActionTypeId: { Category: 'Build', Owner: 'AWS', Provider: 'CodeBuild' },
+            ActionTypeId: { Category: 'Build', Owner: 'AWS', Provider: 'CodeBuild', Version: '1' },
             InputArtifacts: [{ Name: 'Source' }],
             OutputArtifacts: [{ Name: 'Artifact_Build_Build' }],
             RunOrder: 1,
-          },
+          }),
         ],
+        Name: 'Build',
       },
       {
-        Name: 'Test',
         Actions: [
-          {
-            ActionTypeId: { Category: 'Build', Owner: 'AWS', Provider: 'CodeBuild' },
+          Match.objectLike({
+            ActionTypeId: { Category: 'Build', Owner: 'AWS', Provider: 'CodeBuild', Version: '1' },
             InputArtifacts: [{ Name: 'Artifact_Build_Build' }],
             Name: 'ActionSecondStep',
-            OutputArtifacts: [{ Name: 'Artifact_TestStackPipelineSecondStep91726C11' }],
+            OutputArtifacts: [{ Name: 'Artifact_c81eddcbe9657bd312a728fb13df77bc09f9a519b4' }],
             RunOrder: 1,
-          },
+          }),
         ],
+        Name: 'Test',
       },
       {
-        Name: 'Publish',
         Actions: [
-          {
-            ActionTypeId: { Category: 'Build', Owner: 'AWS', Provider: 'CodeBuild' },
-            InputArtifacts: [{ Name: 'Artifact_TestStackPipelineSecondStep91726C11' }],
+          Match.objectLike({
+            ActionTypeId: { Category: 'Build', Owner: 'AWS', Provider: 'CodeBuild', Version: '1' },
+            InputArtifacts: [{ Name: 'Artifact_c81eddcbe9657bd312a728fb13df77bc09f9a519b4' }],
             Name: 'PubPublish',
             RunOrder: 1,
-          },
+          }),
         ],
+        Name: 'Publish',
       },
-    ],
-  }));
+    ]),
+  });
 });
 
 test('autoBuild() can be used to add automatic builds to the pipeline', () => {
@@ -158,13 +162,11 @@ test('autoBuild() can be used to add automatic builds to the pipeline', () => {
     pipelineName: 'HelloPipeline',
     autoBuild: true,
   });
+  const template = Template.fromStack(stack);
 
-  cdk_expect(stack).notTo(haveResource('AWS::Serverless::Application', {
-    Location: {
-      ApplicationId: 'arn:aws:serverlessrepo:us-east-1:277187709615:applications/github-codebuild-logs',
-      SemanticVersion: '1.4.0',
-    },
-  }));
+  template.hasResourceProperties('AWS::CodeBuild::Project', {
+
+  });
 });
 
 test('autoBuild() can be configured to publish logs publically', () => {
@@ -180,8 +182,9 @@ test('autoBuild() can be configured to publish logs publically', () => {
       publicLogs: true,
     },
   });
+  const template = Template.fromStack(stack);
 
-  cdk_expect(stack).to(haveResource('AWS::Serverless::Application', {
+  template.hasResourceProperties('AWS::Serverless::Application', {
     Location: {
       ApplicationId: 'arn:aws:serverlessrepo:us-east-1:277187709615:applications/github-codebuild-logs',
       SemanticVersion: '1.4.0',
@@ -193,7 +196,7 @@ test('autoBuild() can be configured to publish logs publically', () => {
       DeletePreviousComments: 'true',
       CommentOnSuccess: 'true',
     },
-  }));
+  });
 });
 
 test('autoBuild() can be configured with a different buildspec', () => {
@@ -210,8 +213,9 @@ test('autoBuild() can be configured with a different buildspec', () => {
     },
   });
 
+  const template = Template.fromStack(stack);
   // THEN
-  cdk_expect(stack).to(haveResource('AWS::CodeBuild::Project', {
+  template.hasResourceProperties('AWS::CodeBuild::Project', {
     Source: {
       BuildSpec: 'different-buildspec.yaml',
       Location: {
@@ -222,7 +226,7 @@ test('autoBuild() can be configured with a different buildspec', () => {
       },
       Type: 'CODECOMMIT',
     },
-  }));
+  });
 });
 
 test('CodeBuild Project name matches buildProjectName property', () => {
@@ -236,10 +240,11 @@ test('CodeBuild Project name matches buildProjectName property', () => {
     buildProjectName: 'HelloBuild',
   });
 
+  const template = Template.fromStack(stack);
   // THEN
-  cdk_expect(stack).to(haveResourceLike('AWS::CodeBuild::Project', {
+  template.hasResourceProperties('AWS::CodeBuild::Project', {
     Name: 'HelloBuild',
-  }));
+  });
 });
 
 test('CodeBuild Project name is extended from pipelineName property', () => {
@@ -253,9 +258,10 @@ test('CodeBuild Project name is extended from pipelineName property', () => {
   });
 
   // THEN
-  cdk_expect(stack).to(haveResourceLike('AWS::CodeBuild::Project', {
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::CodeBuild::Project', {
     Name: 'HelloPipeline-Build',
-  }));
+  });
 });
 
 test('CodeBuild Project name is left undefined when neither buildProjectName nor pipelineName are specified', () => {
@@ -266,11 +272,12 @@ test('CodeBuild Project name is left undefined when neither buildProjectName nor
   new delivlib.Pipeline(stack, 'Pipeline', {
     repo: createTestRepo(stack),
   });
+  const template = Template.fromStack(stack);
 
   // THEN
-  cdk_expect(stack).to(haveResourceLike('AWS::CodeBuild::Project', {
-    Name: ABSENT,
-  }));
+  template.hasResourceProperties('AWS::CodeBuild::Project', {
+    Name: Match.absent(),
+  });
 });
 
 test('metricFailures', () => {
@@ -355,8 +362,12 @@ function createTestPipelineForConcurrencyTests(stack: Stack, props?: delivlib.Pi
   pipeline.addPublish(new TestPublishable(stack, 'pub5', { project }));
   pipeline.addPublish(new TestPublishable(stack, 'pub6', { project }));
 
-  const template = SynthUtils.synthesize(stack).template;
-  return template.Resources.PipelineBuildPipeline04C6628A.Properties.Stages;
+  const template = Template.fromStack(stack);
+  const capture = new Capture();
+  template.hasResourceProperties('AWS::CodePipeline::Pipeline', {
+    Stages: capture,
+  });
+  return capture.asArray();
 }
 
 function createTestRepo(stack: Stack) {

--- a/lib/__tests__/pipeline.test.ts
+++ b/lib/__tests__/pipeline.test.ts
@@ -164,9 +164,7 @@ test('autoBuild() can be used to add automatic builds to the pipeline', () => {
   });
   const template = Template.fromStack(stack);
 
-  template.hasResourceProperties('AWS::CodeBuild::Project', {
-
-  });
+  template.resourceCountIs('AWS::Serverless::Application', 0);
 });
 
 test('autoBuild() can be configured to publish logs publically', () => {

--- a/lib/__tests__/publishing.test.ts
+++ b/lib/__tests__/publishing.test.ts
@@ -1,11 +1,10 @@
-import { expect as cdk_expect, haveResourceLike } from '@monocdk-experiment/assert';
 import {
   App, Stack,
   aws_codebuild as codebuild,
   aws_codecommit as codecommit,
   aws_kms as kms,
   assertions,
-} from 'monocdk';
+} from 'aws-cdk-lib';
 import * as delivlib from '../../lib';
 
 const { Template, Match } = assertions;
@@ -28,12 +27,13 @@ describe('with standard pipeline', () => {
       nugetApiKeySecret: { secretArn: 'arn:aws:secretsmanager:us-east-1:712950704752:secret:delivlib/nuget-fHzSUD' },
       buildImage: codebuild.LinuxBuildImage.fromDockerRegistry('xyz'),
     });
+    const template = Template.fromStack(stack);
 
-    cdk_expect(stack).to(haveResourceLike('AWS::CodeBuild::Project', {
+    template.hasResourceProperties('AWS::CodeBuild::Project', {
       Environment: {
         Image: 'xyz',
       },
-    }));
+    });
   });
 
   test('can configure build image for Maven publishing', () => {
@@ -56,12 +56,13 @@ describe('with standard pipeline', () => {
       stagingProfileId: '68a05363083174',
       buildImage: codebuild.LinuxBuildImage.fromDockerRegistry('xyz'),
     });
+    const template = Template.fromStack(stack);
 
-    cdk_expect(stack).to(haveResourceLike('AWS::CodeBuild::Project', {
+    template.hasResourceProperties('AWS::CodeBuild::Project', {
       Environment: {
         Image: 'xyz',
       },
-    }));
+    });
   });
 
   test('can control stage name', () => {

--- a/lib/__tests__/registry-sync/mirror-source.test.ts
+++ b/lib/__tests__/registry-sync/mirror-source.test.ts
@@ -223,7 +223,7 @@ describe('RegistryImageSource', () => {
       // THEN
       expect(result.commands).toEqual([
         'rm -rf myrepository.zip myrepository',
-        expect.stringMatching(/aws s3 cp s3.* myrepository.zip/),
+        expect.stringMatching(/aws s3 cp s3:.* myrepository.zip/),
         'unzip myrepository.zip -d myrepository',
         'docker build --pull -t myregistry/myrepository:latest --build-arg arg1=val1 --build-arg arg2=val2 myrepository',
       ]);

--- a/lib/__tests__/test-stack.ts
+++ b/lib/__tests__/test-stack.ts
@@ -11,7 +11,7 @@ import * as delivlib from '../../lib';
 const testDir = path.join(__dirname, 'delivlib-tests');
 
 export class TestStack extends Stack {
-  constructor(parent: App, id: string, props: StackProps = {}) {
+  constructor(parent: App, id: string, props: StackProps = { }) {
     super(parent, id, props);
 
     //

--- a/lib/__tests__/test-stack.ts
+++ b/lib/__tests__/test-stack.ts
@@ -4,14 +4,14 @@ import {
   aws_events as events,
   aws_iam as iam,
   aws_kms as kms,
-} from 'monocdk';
+} from 'aws-cdk-lib';
 import * as delivlib from '../../lib';
 
 
 const testDir = path.join(__dirname, 'delivlib-tests');
 
 export class TestStack extends Stack {
-  constructor(parent: App, id: string, props: StackProps = { }) {
+  constructor(parent: App, id: string, props: StackProps = {}) {
     super(parent, id, props);
 
     //
@@ -61,7 +61,7 @@ export class TestStack extends Stack {
 
     const role = new iam.Role(this, 'AssumeMe', {
       assumedBy: new iam.AccountPrincipal(Stack.of(this).account),
-      externalId,
+      externalIds: [externalId],
     });
 
     pipeline.addTest('AssumeRole', {

--- a/lib/__tests__/watcher.test.ts
+++ b/lib/__tests__/watcher.test.ts
@@ -1,6 +1,6 @@
-import '@monocdk-experiment/assert/jest';
-import { Stack } from 'monocdk';
-import { Pipeline } from 'monocdk/aws-codepipeline';
+import { Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { Pipeline } from 'aws-cdk-lib/aws-codepipeline';
 import { PipelineWatcher } from '../../lib/pipeline-watcher';
 
 const props = {
@@ -13,10 +13,11 @@ describe('PipelineWatcher', () => {
     const stack = new Stack();
     const pipeline = Pipeline.fromPipelineArn(stack, 'Pipeline', 'arn:aws:codepipeline:us-east-1:012345789:MyPipeline');
     new PipelineWatcher(stack, 'Watcher', { pipeline, ...props });
+    const template = Template.fromStack(stack);
 
-    expect(stack).toHaveResource('AWS::Events::Rule');
-    expect(stack).toHaveResource('AWS::Lambda::Function');
-    expect(stack).toHaveResource('AWS::CloudWatch::Alarm', {
+    template.resourceCountIs('AWS::Events::Rule', 1);
+    template.resourceCountIs('AWS::Lambda::Function', 1);
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
       ComparisonOperator: 'GreaterThanOrEqualToThreshold',
       EvaluationPeriods: 1,
       AlarmDescription: 'Pipeline MyPipeline has failed stages',
@@ -38,8 +39,9 @@ describe('PipelineWatcher', () => {
     const stack = new Stack();
     const pipeline = Pipeline.fromPipelineArn(stack, 'Pipeline', 'arn:aws:codepipeline:us-east-1:012345789:MyPipeline');
     new PipelineWatcher(stack, 'Watcher', { pipeline, title: 'MyTitle', ...props });
+    const template = Template.fromStack(stack);
 
-    expect(stack).toHaveResource('AWS::CloudWatch::Alarm', {
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
       AlarmDescription: 'Pipeline MyTitle has failed stages',
     });
   });
@@ -49,7 +51,8 @@ describe('PipelineWatcher', () => {
     const pipeline = Pipeline.fromPipelineArn(stack, 'Pipeline', 'arn:aws:codepipeline:us-east-1:012345789:MyPipeline');
     new PipelineWatcher(stack, 'Watcher', { pipeline, ...props });
 
-    expect(stack).toHaveResourceLike('AWS::IAM::Policy', {
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::IAM::Policy', {
       PolicyDocument: {
         Statement: [
           {
@@ -77,7 +80,8 @@ describe('PipelineWatcher', () => {
     const pipeline = Pipeline.fromPipelineArn(stack, 'Pipeline', 'arn:aws:codepipeline:us-east-1:012345789:MyPipeline');
     new PipelineWatcher(stack, 'Watcher', { pipeline, ...props });
 
-    expect(stack).toHaveResource('AWS::CloudWatch::Alarm', {
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
       TreatMissingData: 'ignore',
     });
   });

--- a/lib/auto-build.ts
+++ b/lib/auto-build.ts
@@ -1,8 +1,9 @@
 import {
-  Construct, Token, SecretValue,
+  Token, SecretValue,
   aws_codebuild as codebuild,
   aws_sam as serverless,
-} from 'monocdk';
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import { BuildEnvironmentProps, createBuildEnvironment } from './build-env';
 import { IRepo } from './repo';
 

--- a/lib/build-env.ts
+++ b/lib/build-env.ts
@@ -1,4 +1,4 @@
-import { aws_codebuild as cbuild } from 'monocdk';
+import { aws_codebuild as cbuild } from 'aws-cdk-lib';
 
 export interface BuildEnvironmentProps {
   computeType?: cbuild.ComputeType;

--- a/lib/canary.ts
+++ b/lib/canary.ts
@@ -30,7 +30,7 @@ export class Canary extends Construct {
   constructor(scope: Construct, id: string, props: CanaryProps) {
     super(scope, id);
 
-    const env = props.environment || {};
+    const env = props.environment || { };
     if (!('IS_CANARY' in env)) {
       env.IS_CANARY = 'true';
     }

--- a/lib/canary.ts
+++ b/lib/canary.ts
@@ -1,10 +1,10 @@
 import {
-  Construct,
   aws_cloudwatch as cloudwatch,
   aws_codebuild as cbuild,
   aws_events as events,
   aws_events_targets as events_targets,
-} from 'monocdk';
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import { Shellable, ShellableProps } from './shellable';
 
 
@@ -30,7 +30,7 @@ export class Canary extends Construct {
   constructor(scope: Construct, id: string, props: CanaryProps) {
     super(scope, id);
 
-    const env = props.environment || { };
+    const env = props.environment || {};
     if (!('IS_CANARY' in env)) {
       env.IS_CANARY = 'true';
     }

--- a/lib/change-controller.ts
+++ b/lib/change-controller.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import {
-  CfnOutput, Construct, Duration, RemovalPolicy,
+  CfnOutput, Duration, RemovalPolicy,
   aws_cloudwatch as cloudwatch,
   aws_codepipeline as cp,
   aws_events as events,
@@ -10,8 +10,8 @@ import {
   aws_s3 as s3,
   aws_s3_notifications as s3_notifications,
   aws_lambda_nodejs as nodejs,
-}
-  from 'monocdk';
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 
 export interface ChangeControllerProps {
   /**
@@ -104,10 +104,11 @@ export class ChangeController extends Construct {
     }
 
     this.failureAlarm = new cloudwatch.Alarm(this, 'Failed', {
-      metric: fn.metricErrors(),
+      metric: fn.metricErrors({
+        period: Duration.seconds(300),
+      }),
       threshold: 1,
       datapointsToAlarm: 1,
-      period: Duration.seconds(300),
       evaluationPeriods: 1,
     });
 

--- a/lib/chime-notifier/chime-notifier.ts
+++ b/lib/chime-notifier/chime-notifier.ts
@@ -55,7 +55,7 @@ export class ChimeNotifier extends Construct {
       const notifierLambda = new lambda.SingletonFunction(this, 'Default', {
         handler: 'index.handler',
         uuid: '0f4a3ee0-692e-4249-932f-a46a833886d8',
-        code: lambda.Code.fromAsset(path.join(__dirname, '../../assets/lib/chime-notifier/notifier-handler')),
+        code: lambda.Code.fromAsset(path.join(__dirname, 'handler')),
         runtime: lambda.Runtime.NODEJS_12_X,
         timeout: Duration.minutes(5),
       });

--- a/lib/chime-notifier/chime-notifier.ts
+++ b/lib/chime-notifier/chime-notifier.ts
@@ -1,12 +1,13 @@
 import * as path from 'path';
 import {
-  Construct, Duration,
+  Duration,
   aws_codepipeline as cpipeline,
   aws_iam as iam,
   aws_lambda as lambda,
   aws_events as events,
   aws_events_targets as events_targets,
-} from 'monocdk';
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 
 export interface ChimeNotifierOptions {
   /**
@@ -54,7 +55,7 @@ export class ChimeNotifier extends Construct {
       const notifierLambda = new lambda.SingletonFunction(this, 'Default', {
         handler: 'index.handler',
         uuid: '0f4a3ee0-692e-4249-932f-a46a833886d8',
-        code: lambda.Code.fromAsset(path.join(__dirname, 'handler')),
+        code: lambda.Code.fromAsset(path.join(__dirname, '../../assets/lib/chime-notifier/notifier-handler')),
         runtime: lambda.Runtime.NODEJS_12_X,
         timeout: Duration.minutes(5),
       });

--- a/lib/code-signing/certificate-signing-request.ts
+++ b/lib/code-signing/certificate-signing-request.ts
@@ -1,9 +1,10 @@
 import * as path from 'path';
 import {
-  Construct, Duration,
-  aws_cloudformation as cfn,
+  Duration,
+  CustomResource,
   aws_lambda as lambda,
-} from 'monocdk';
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import { hashFileOrDirectory } from '../util';
 import { RsaPrivateKeySecret } from './private-key';
 
@@ -65,8 +66,8 @@ export class CertificateSigningRequest extends Construct {
       })],
     });
 
-    const csr = new cfn.CustomResource(this, 'Resource', {
-      provider: cfn.CustomResourceProvider.lambda(customResource),
+    const csr = new CustomResource(this, 'Resource', {
+      serviceToken: customResource.functionArn,
       resourceType: 'Custom::CertificateSigningRequest',
       properties: {
         resourceVersion: hashFileOrDirectory(codeLocation),

--- a/lib/code-signing/certificate-signing-request.ts
+++ b/lib/code-signing/certificate-signing-request.ts
@@ -69,6 +69,7 @@ export class CertificateSigningRequest extends Construct {
     const csr = new CustomResource(this, 'Resource', {
       serviceToken: customResource.functionArn,
       resourceType: 'Custom::CertificateSigningRequest',
+      pascalCaseProperties: true,
       properties: {
         resourceVersion: hashFileOrDirectory(codeLocation),
         // Private key

--- a/lib/code-signing/code-signing-certificate.ts
+++ b/lib/code-signing/code-signing-certificate.ts
@@ -1,10 +1,11 @@
 import {
-  Construct, CfnOutput, IConstruct, RemovalPolicy, Stack,
+  CfnOutput, RemovalPolicy, Stack,
   aws_iam as iam,
   aws_kms as kms,
   aws_secretsmanager as secretsManager,
   aws_ssm as ssm,
-} from 'monocdk';
+} from 'aws-cdk-lib';
+import { Construct, IConstruct } from 'constructs';
 import { ICredentialPair } from '../credential-pair';
 import * as permissions from '../permissions';
 import { DistinguishedName } from './certificate-signing-request';
@@ -118,7 +119,7 @@ export class CodeSigningCertificate extends Construct implements ICodeSigningCer
 
     this.credential = secretsManager.Secret.fromSecretAttributes(this, 'Credential', {
       encryptionKey: props.secretEncryptionKey,
-      secretArn: privateKey.secretArn,
+      secretCompleteArn: privateKey.secretArn,
     });
 
     let certificate = props.pemCertificate;
@@ -158,7 +159,7 @@ export class CodeSigningCertificate extends Construct implements ICodeSigningCer
       secretArn: this.credential.secretArn,
     }, principal);
 
-    principal.addToPolicy(new iam.PolicyStatement({
+    principal.addToPrincipalPolicy(new iam.PolicyStatement({
       actions: ['ssm:GetParameter'],
       resources: [Stack.of(this).formatArn({
         // TODO: This is a workaround until https://github.com/awslabs/aws-cdk/pull/1726 is released

--- a/lib/code-signing/private-key.ts
+++ b/lib/code-signing/private-key.ts
@@ -113,6 +113,7 @@ export class RsaPrivateKeySecret extends Construct {
     const privateKey = new CustomResource(this, 'Resource', {
       serviceToken: customResource.functionArn,
       resourceType: 'Custom::RsaPrivateKeySecret',
+      pascalCaseProperties: true,
       properties: {
         resourceVersion: hashFileOrDirectory(codeLocation),
         description: props.description,

--- a/lib/code-signing/private-key.ts
+++ b/lib/code-signing/private-key.ts
@@ -1,11 +1,12 @@
 import * as path from 'path';
 import {
-  Construct, Duration, RemovalPolicy, Stack,
-  aws_cloudformation as cfn,
+  Duration, RemovalPolicy, Stack,
+  ArnFormat, CustomResource,
   aws_iam as iam,
   aws_kms as kms,
   aws_lambda as lambda,
-} from 'monocdk';
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import { hashFileOrDirectory } from '../util';
 import { CertificateSigningRequest, DistinguishedName } from './certificate-signing-request';
 
@@ -79,7 +80,7 @@ export class RsaPrivateKeySecret extends Construct {
     this.secretArnLike = Stack.of(this).formatArn({
       service: 'secretsmanager',
       resource: 'secret',
-      sep: ':',
+      arnFormat: ArnFormat.COLON_RESOURCE_NAME,
       // The ARN of a secret has "-" followed by 6 random characters appended at the end
       resourceName: `${props.secretName}-??????`,
     });
@@ -109,8 +110,8 @@ export class RsaPrivateKeySecret extends Construct {
       }));
     }
 
-    const privateKey = new cfn.CustomResource(this, 'Resource', {
-      provider: cfn.CustomResourceProvider.lambda(customResource),
+    const privateKey = new CustomResource(this, 'Resource', {
+      serviceToken: customResource.functionArn,
       resourceType: 'Custom::RsaPrivateKeySecret',
       properties: {
         resourceVersion: hashFileOrDirectory(codeLocation),
@@ -174,7 +175,7 @@ export class RsaPrivateKeySecret extends Construct {
    * @param grantee the principal to which permissions should be granted.
    */
   public grantGetSecretValue(grantee: iam.IPrincipal): void {
-    grantee.addToPolicy(new iam.PolicyStatement({
+    grantee.addToPrincipalPolicy(new iam.PolicyStatement({
       actions: ['secretsmanager:GetSecretValue'],
       resources: [this.secretArn],
     }));
@@ -193,7 +194,7 @@ export class RsaPrivateKeySecret extends Construct {
           },
         },
       }));
-      grantee.addToPolicy(new iam.PolicyStatement({
+      grantee.addToPrincipalPolicy(new iam.PolicyStatement({
         actions: ['kms:Decrypt'],
         resources: [this.masterKey.keyArn],
         conditions: {

--- a/lib/credential-pair.ts
+++ b/lib/credential-pair.ts
@@ -1,7 +1,7 @@
 import {
   aws_ssm as ssm,
   aws_secretsmanager as secretsManager,
-} from 'monocdk';
+} from 'aws-cdk-lib';
 
 
 /**

--- a/lib/open-pgp-key-pair.ts
+++ b/lib/open-pgp-key-pair.ts
@@ -163,6 +163,7 @@ export class OpenPGPKeyPair extends Construct implements ICredentialPair {
 
     const secret = new CustomResource(this, 'Resource', {
       serviceToken: fn.functionArn,
+      pascalCaseProperties: true,
       properties: {
         resourceVersion: hashFileOrDirectory(codeLocation),
         identity: props.identity,

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -1,4 +1,4 @@
-import { aws_iam as iam } from 'monocdk';
+import { aws_iam as iam } from 'aws-cdk-lib';
 
 
 /**
@@ -56,13 +56,13 @@ export type Region =
  * Give the role permission to read a particular secret and its key.
  */
 export function grantSecretRead(secret: ExternalSecret, identity: iam.IPrincipal) {
-  identity.addToPolicy(new iam.PolicyStatement({
+  identity.addToPrincipalPolicy(new iam.PolicyStatement({
     resources: [secret.secretArn],
     actions: ['secretsmanager:ListSecrets', 'secretsmanager:DescribeSecret', 'secretsmanager:GetSecretValue'],
   }));
 
   if (secret.keyArn) {
-    identity.addToPolicy(new iam.PolicyStatement({
+    identity.addToPrincipalPolicy(new iam.PolicyStatement({
       resources: [secret.keyArn],
       actions: ['kms:Decrypt'],
     }));
@@ -73,7 +73,7 @@ export function grantSecretRead(secret: ExternalSecret, identity: iam.IPrincipal
  * Give the role permission to assume another role.
  */
 export function grantAssumeRole(roleToAssumeArn: string, identity: iam.IPrincipal) {
-  identity.addToPolicy(new iam.PolicyStatement({
+  identity.addToPrincipalPolicy(new iam.PolicyStatement({
     resources: [roleToAssumeArn],
     actions: ['sts:AssumeRole'],
   }));

--- a/lib/pipeline-notifications/slack.ts
+++ b/lib/pipeline-notifications/slack.ts
@@ -3,7 +3,7 @@ import {
   aws_chatbot as chatbot,
   aws_codestarnotifications as starnotifs,
   Stack,
-} from 'monocdk';
+} from 'aws-cdk-lib';
 import { IPipelineNotification, PipelineNotificationBindOptions } from '../';
 
 /**

--- a/lib/pipeline-watcher/watcher.ts
+++ b/lib/pipeline-watcher/watcher.ts
@@ -1,13 +1,13 @@
 import * as path from 'path';
 import {
-  Construct,
   aws_cloudwatch as cloudwatch,
   aws_codepipeline as cpipeline,
   aws_events as events,
   aws_events_targets as events_targets,
   aws_iam as iam,
   aws_lambda as lambda,
-} from 'monocdk';
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 
 export interface PipelineWatcherProps {
   /**
@@ -92,7 +92,7 @@ export class PipelineWatcher extends Construct {
         metricName: props.failureMetricName,
         namespace: props.metricNamespace,
         statistic: cloudwatch.Statistic.MAXIMUM,
-        dimensions: {
+        dimensionsMap: {
           Pipeline: props.pipeline.pipelineName,
         },
       }),

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -1,5 +1,5 @@
 import {
-  Construct, Duration, IConstruct,
+  Duration,
   aws_cloudwatch as cloudwatch,
   aws_codebuild as cbuild,
   aws_codepipeline as cpipeline,
@@ -9,7 +9,8 @@ import {
   aws_iam as iam, aws_s3 as s3,
   aws_sns as sns,
   aws_sns_subscriptions as sns_subs,
-} from 'monocdk';
+} from 'aws-cdk-lib';
+import { Construct, IConstruct } from 'constructs';
 
 import { AutoBuild, AutoBuildOptions } from './auto-build';
 import { createBuildEnvironment } from './build-env';
@@ -204,7 +205,7 @@ export class Pipeline extends Construct {
   public readonly pipeline: cpipeline.Pipeline;
   private readonly branch: string;
   private readonly notify?: sns.Topic;
-  private stages: { [name: string]: cpipeline.IStage } = { };
+  private stages: { [name: string]: cpipeline.IStage } = {};
 
   private readonly concurrency?: number;
   private readonly repo: IRepo;
@@ -291,7 +292,8 @@ export class Pipeline extends Construct {
    * @return The Shellable and the Action added to the pipeline.
    */
   public addShellable(stageName: string, id: string, options: AddShellableOptions): {
-    shellable: Shellable; action: cpipeline_actions.CodeBuildAction;} {
+    shellable: Shellable; action: cpipeline_actions.CodeBuildAction;
+  } {
     const stage = this.getOrCreateStage(stageName);
 
     const sh = new Shellable(this, id, options);
@@ -308,7 +310,7 @@ export class Pipeline extends Construct {
     return { shellable: sh, action };
   }
 
-  public addTest(id: string, props: ShellableProps): {shellable: Shellable; action: cpipeline_actions.CodeBuildAction} {
+  public addTest(id: string, props: ShellableProps): { shellable: Shellable; action: cpipeline_actions.CodeBuildAction } {
     return this.addShellable(TEST_STAGE_NAME, id, {
       actionName: `Test${id}`,
       failureNotification: `Test ${id} failed`,
@@ -465,7 +467,7 @@ export class Pipeline extends Construct {
    * Enables automatic builds of pull requests in the Github repository and posts the
    * results back as a comment with a public link to the build logs.
    */
-  public autoBuild(options: AutoBuildOptions = { }): AutoBuild {
+  public autoBuild(options: AutoBuildOptions = {}): AutoBuild {
     return new AutoBuild(this, 'AutoBuild', {
       environment: this.buildEnvironment,
       repo: this.repo,
@@ -481,7 +483,7 @@ export class Pipeline extends Construct {
     return new cloudwatch.Metric({
       namespace: METRIC_NAMESPACE,
       metricName: FAILURE_METRIC_NAME,
-      dimensions: {
+      dimensionsMap: {
         Pipeline: this.pipeline.pipelineName,
       },
       statistic: 'Sum',
@@ -497,7 +499,7 @@ export class Pipeline extends Construct {
       return new cloudwatch.Metric({
         namespace: METRIC_NAMESPACE,
         metricName: FAILURE_METRIC_NAME,
-        dimensions: {
+        dimensionsMap: {
           Pipeline: this.pipeline.pipelineName,
           Action: action.actionProperties.actionName,
         },

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -205,7 +205,7 @@ export class Pipeline extends Construct {
   public readonly pipeline: cpipeline.Pipeline;
   private readonly branch: string;
   private readonly notify?: sns.Topic;
-  private stages: { [name: string]: cpipeline.IStage } = {};
+  private stages: { [name: string]: cpipeline.IStage } = { };
 
   private readonly concurrency?: number;
   private readonly repo: IRepo;
@@ -292,8 +292,7 @@ export class Pipeline extends Construct {
    * @return The Shellable and the Action added to the pipeline.
    */
   public addShellable(stageName: string, id: string, options: AddShellableOptions): {
-    shellable: Shellable; action: cpipeline_actions.CodeBuildAction;
-  } {
+    shellable: Shellable; action: cpipeline_actions.CodeBuildAction;} {
     const stage = this.getOrCreateStage(stageName);
 
     const sh = new Shellable(this, id, options);
@@ -310,7 +309,7 @@ export class Pipeline extends Construct {
     return { shellable: sh, action };
   }
 
-  public addTest(id: string, props: ShellableProps): { shellable: Shellable; action: cpipeline_actions.CodeBuildAction } {
+  public addTest(id: string, props: ShellableProps): {shellable: Shellable; action: cpipeline_actions.CodeBuildAction} {
     return this.addShellable(TEST_STAGE_NAME, id, {
       actionName: `Test${id}`,
       failureNotification: `Test ${id} failed`,
@@ -467,7 +466,7 @@ export class Pipeline extends Construct {
    * Enables automatic builds of pull requests in the Github repository and posts the
    * results back as a comment with a public link to the build logs.
    */
-  public autoBuild(options: AutoBuildOptions = {}): AutoBuild {
+  public autoBuild(options: AutoBuildOptions = { }): AutoBuild {
     return new AutoBuild(this, 'AutoBuild', {
       environment: this.buildEnvironment,
       repo: this.repo,

--- a/lib/publishing.ts
+++ b/lib/publishing.ts
@@ -1,12 +1,13 @@
 import * as path from 'path';
 import {
-  Construct, Stack,
+  Stack,
   aws_codebuild as cbuild,
   aws_codepipeline as cpipeline,
   aws_codepipeline_actions as cpipeline_actions,
   aws_iam as iam,
   aws_s3 as s3,
-} from 'monocdk';
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import { ICodeSigningCertificate } from './code-signing';
 import { OpenPGPKeyPair } from './open-pgp-key-pair';
 import * as permissions from './permissions';
@@ -161,7 +162,7 @@ export class PublishToNpmProject extends Construct implements IPublisher {
     const access = props.access ?? NpmAccess.PUBLIC;
 
     const shellable = new Shellable(this, 'Default', {
-      platform: new LinuxPlatform(cbuild.LinuxBuildImage.UBUNTU_14_04_NODEJS_10_1_0),
+      platform: new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_5_0),
       scriptDirectory: path.join(__dirname, 'publishing', 'npm'),
       entrypoint: 'publish.sh',
       environment: {
@@ -228,7 +229,7 @@ export class PublishToNuGetProject extends Construct implements IPublisher {
   constructor(parent: Construct, id: string, props: PublishToNuGetProjectProps) {
     super(parent, id);
 
-    const environment: { [key: string]: string } = { };
+    const environment: { [key: string]: string } = {};
 
     environment.FOR_REAL = props.dryRun === undefined ? 'false' : (!props.dryRun).toString();
 
@@ -321,7 +322,7 @@ export class PublishDocsToGitHubProject extends Construct implements IPublisher 
     const forReal = props.dryRun === undefined ? 'false' : (!props.dryRun).toString();
 
     const shellable = new Shellable(this, 'Default', {
-      platform: new LinuxPlatform(cbuild.LinuxBuildImage.UBUNTU_14_04_NODEJS_10_1_0),
+      platform: new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_5_0),
       scriptDirectory: path.join(__dirname, 'publishing', 'docs'),
       entrypoint: 'publish.sh',
       environment: {
@@ -426,7 +427,7 @@ export class PublishToGitHub extends Construct implements IPublisher {
     }
 
     const shellable = new Shellable(this, 'Default', {
-      platform: new LinuxPlatform(cbuild.LinuxBuildImage.UBUNTU_14_04_NODEJS_10_1_0),
+      platform: new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_5_0),
       scriptDirectory: path.join(__dirname, 'publishing', 'github'),
       entrypoint: 'publish.sh',
       environment: noUndefined({
@@ -493,7 +494,7 @@ export class PublishToS3 extends Construct implements IPublisher {
     const forReal = props.dryRun === undefined ? 'false' : (!props.dryRun).toString();
 
     const shellable = new Shellable(this, 'Default', {
-      platform: new LinuxPlatform(cbuild.LinuxBuildImage.UBUNTU_14_04_NODEJS_8_11_0),
+      platform: new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_5_0),
       scriptDirectory: path.join(__dirname, 'publishing', 's3'),
       entrypoint: 'publish.sh',
       environment: {
@@ -547,7 +548,7 @@ export class PublishToPyPi extends Construct {
     const forReal = props.dryRun === undefined ? 'false' : (!props.dryRun).toString();
 
     const shellable = new Shellable(this, 'Default', {
-      platform: new LinuxPlatform(cbuild.LinuxBuildImage.UBUNTU_14_04_PYTHON_3_6_5),
+      platform: new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_5_0),
       scriptDirectory: path.join(__dirname, 'publishing', 'pypi'),
       entrypoint: 'publish.sh',
       environment: {

--- a/lib/pull-request/bump.ts
+++ b/lib/pull-request/bump.ts
@@ -1,4 +1,4 @@
-import * as cdk from 'monocdk';
+import { Construct } from 'constructs';
 import { WritableGitHubRepo } from '../repo';
 import { AutoPullRequest, AutoPullRequestOptions } from './pr';
 
@@ -78,14 +78,14 @@ export interface AutoBumpProps extends AutoPullRequestOptions {
 
 }
 
-export class AutoBump extends cdk.Construct {
+export class AutoBump extends Construct {
 
   /**
    * The underlying AutoPullRequest construct.
    */
   public readonly pr: AutoPullRequest;
 
-  constructor(parent: cdk.Construct, id: string, props: AutoBumpProps) {
+  constructor(parent: Construct, id: string, props: AutoBumpProps) {
     super(parent, id);
 
     const branchName = props.head?.name ?? 'bump/$VERSION';

--- a/lib/pull-request/merge-back.ts
+++ b/lib/pull-request/merge-back.ts
@@ -1,4 +1,4 @@
-import * as cdk from 'monocdk';
+import { Construct } from 'constructs';
 import { WritableGitHubRepo } from '../repo';
 import * as pr from './pr';
 
@@ -99,14 +99,14 @@ export interface AutoMergeBackProps extends AutoMergeBackOptions {
   repo: WritableGitHubRepo;
 }
 
-export class AutoMergeBack extends cdk.Construct {
+export class AutoMergeBack extends Construct {
 
   /**
    * The underlying AutoPullRequest construct.
    */
   public readonly pr: pr.AutoPullRequest;
 
-  constructor(parent: cdk.Construct, id: string, props: AutoMergeBackProps) {
+  constructor(parent: Construct, id: string, props: AutoMergeBackProps) {
     super(parent, id);
 
     const versionCommand = props.versionCommand ?? 'git describe';

--- a/lib/pull-request/pr.ts
+++ b/lib/pull-request/pr.ts
@@ -245,8 +245,8 @@ export class AutoPullRequest extends Construct {
       // there's no way to stop a BuildSpec execution halfway through without throwing an error. Believe me, I
       // checked the code. Instead we define a variable that we will switch all other lines on/off.
       commands.push(`${this.props.condition} ` +
-        '&& { echo \'Skip condition is met, skipping...\' && export SKIP=true; } ' +
-        '|| { echo \'Skip condition is not met, continuing...\' && export SKIP=false; }');
+      '&& { echo \'Skip condition is met, skipping...\' && export SKIP=true; } ' +
+      '|| { echo \'Skip condition is not met, continuing...\' && export SKIP=false; }');
     }
 
     // read the token
@@ -367,8 +367,8 @@ export class AutoPullRequest extends Construct {
 
     return [
       'aws secretsmanager get-secret-value '
-      + `--secret-id "${this.props.repo.sshKeySecret.secretArn}" `
-      + '--output=text --query=SecretString > ~/.ssh/id_rsa',
+        + `--secret-id "${this.props.repo.sshKeySecret.secretArn}" `
+        + '--output=text --query=SecretString > ~/.ssh/id_rsa',
       'mkdir -p ~/.ssh',
       'chmod 0600 ~/.ssh/id_rsa ~/.ssh/config',
       'ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts',
@@ -380,8 +380,8 @@ export class AutoPullRequest extends Construct {
     // We will do nothing and set `SKIP=true` if the head ref is an ancestor of the base branch (no PR could be created)
     return [
       `git merge-base --is-ancestor ${this.props.head.name} origin/${this.baseBranch}`
-      + ` && { echo "Skipping: ${this.props.head.name} is an ancestor of origin/${this.baseBranch}"; export SKIP=true; }`
-      + ` || { echo "Pushing: ${this.props.head.name} is ahead of origin/${this.baseBranch}"; export SKIP=false; }`,
+        + ` && { echo "Skipping: ${this.props.head.name} is an ancestor of origin/${this.baseBranch}"; export SKIP=true; }`
+        + ` || { echo "Pushing: ${this.props.head.name} is ahead of origin/${this.baseBranch}"; export SKIP=false; }`,
       `git remote add origin_ssh ${this.props.repo.repositoryUrlSsh}`,
       // Need `--atomic`, otherwise `git push` might successfully push the tags but not to `main`.
       `git push --atomic --follow-tags origin_ssh ${this.props.head.name}:${this.props.head.name}`,
@@ -399,7 +399,7 @@ export class AutoPullRequest extends Construct {
     return [
       `${this.githubCurlGet(`/search/issues?q=${encodeURIComponent(filters.join(' '))}`, '-o search.json')}`,
       'node -e \'process.exitCode = require("./search.json").total_count\''
-      + ` || { echo "Found open PRs with label ${labels}, skipping PR."; export SKIP=true; }`,
+        + ` || { echo "Found open PRs with label ${labels}, skipping PR."; export SKIP=true; }`,
     ];
   }
 
@@ -428,7 +428,7 @@ export class AutoPullRequest extends Construct {
     commands.push(this.githubCurl('/pulls/$PR_NUMBER', '-X PATCH', { body: body }));
 
     if (this.props.labels && this.props.labels.length > 0) {
-      // apply labels.
+    // apply labels.
       commands.push(this.githubCurl('/issues/$PR_NUMBER/labels', '-X POST', { labels: this.props.labels }));
     }
 

--- a/lib/pull-request/pr.ts
+++ b/lib/pull-request/pr.ts
@@ -1,10 +1,11 @@
 import {
-  Construct, Duration,
+  Duration,
   aws_cloudwatch as cloudwatch,
   aws_codebuild as cbuild,
   aws_events as events,
   aws_events_targets as events_targets,
-} from 'monocdk';
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import { BuildEnvironmentProps, createBuildEnvironment } from '../build-env';
 import * as permissions from '../permissions';
 import { WritableGitHubRepo } from '../repo';
@@ -244,8 +245,8 @@ export class AutoPullRequest extends Construct {
       // there's no way to stop a BuildSpec execution halfway through without throwing an error. Believe me, I
       // checked the code. Instead we define a variable that we will switch all other lines on/off.
       commands.push(`${this.props.condition} ` +
-      '&& { echo \'Skip condition is met, skipping...\' && export SKIP=true; } ' +
-      '|| { echo \'Skip condition is not met, continuing...\' && export SKIP=false; }');
+        '&& { echo \'Skip condition is met, skipping...\' && export SKIP=true; } ' +
+        '|| { echo \'Skip condition is not met, continuing...\' && export SKIP=false; }');
     }
 
     // read the token
@@ -366,8 +367,8 @@ export class AutoPullRequest extends Construct {
 
     return [
       'aws secretsmanager get-secret-value '
-        + `--secret-id "${this.props.repo.sshKeySecret.secretArn}" `
-        + '--output=text --query=SecretString > ~/.ssh/id_rsa',
+      + `--secret-id "${this.props.repo.sshKeySecret.secretArn}" `
+      + '--output=text --query=SecretString > ~/.ssh/id_rsa',
       'mkdir -p ~/.ssh',
       'chmod 0600 ~/.ssh/id_rsa ~/.ssh/config',
       'ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts',
@@ -379,8 +380,8 @@ export class AutoPullRequest extends Construct {
     // We will do nothing and set `SKIP=true` if the head ref is an ancestor of the base branch (no PR could be created)
     return [
       `git merge-base --is-ancestor ${this.props.head.name} origin/${this.baseBranch}`
-        + ` && { echo "Skipping: ${this.props.head.name} is an ancestor of origin/${this.baseBranch}"; export SKIP=true; }`
-        + ` || { echo "Pushing: ${this.props.head.name} is ahead of origin/${this.baseBranch}"; export SKIP=false; }`,
+      + ` && { echo "Skipping: ${this.props.head.name} is an ancestor of origin/${this.baseBranch}"; export SKIP=true; }`
+      + ` || { echo "Pushing: ${this.props.head.name} is ahead of origin/${this.baseBranch}"; export SKIP=false; }`,
       `git remote add origin_ssh ${this.props.repo.repositoryUrlSsh}`,
       // Need `--atomic`, otherwise `git push` might successfully push the tags but not to `main`.
       `git push --atomic --follow-tags origin_ssh ${this.props.head.name}:${this.props.head.name}`,
@@ -398,7 +399,7 @@ export class AutoPullRequest extends Construct {
     return [
       `${this.githubCurlGet(`/search/issues?q=${encodeURIComponent(filters.join(' '))}`, '-o search.json')}`,
       'node -e \'process.exitCode = require("./search.json").total_count\''
-        + ` || { echo "Found open PRs with label ${labels}, skipping PR."; export SKIP=true; }`,
+      + ` || { echo "Found open PRs with label ${labels}, skipping PR."; export SKIP=true; }`,
     ];
   }
 
@@ -427,7 +428,7 @@ export class AutoPullRequest extends Construct {
     commands.push(this.githubCurl('/pulls/$PR_NUMBER', '-X PATCH', { body: body }));
 
     if (this.props.labels && this.props.labels.length > 0) {
-    // apply labels.
+      // apply labels.
       commands.push(this.githubCurl('/issues/$PR_NUMBER/labels', '-X POST', { labels: this.props.labels }));
     }
 

--- a/lib/registry-sync/ecr-mirror.ts
+++ b/lib/registry-sync/ecr-mirror.ts
@@ -1,5 +1,5 @@
 import {
-  Construct, IAspect, IConstruct, Lazy, Stack, Token,
+  IAspect, Lazy, Stack, Token,
   aws_ecr as ecr,
   aws_codebuild as codebuild,
   aws_events as events,
@@ -7,7 +7,8 @@ import {
   aws_s3_assets as s3Assets,
   aws_secretsmanager as sm,
   custom_resources as cr,
-} from 'monocdk';
+} from 'aws-cdk-lib';
+import { Construct, IConstruct } from 'constructs';
 import { MirrorSource } from './mirror-source';
 
 /**
@@ -184,7 +185,7 @@ export class EcrMirror extends Construct {
           physicalResourceId: cr.PhysicalResourceId.of('EcrRegistryExecution'),
 
           // need since the default reponse if greater than the 4k limit for custom resources.
-          outputPath: 'build.id',
+          outputPaths: ['build.id'],
         },
       });
     }
@@ -223,7 +224,7 @@ export class EcrMirror extends Construct {
  * with ECR equivalents found in the EcrMirror.
  */
 export class EcrMirrorAspect implements IAspect {
-  constructor(private readonly mirror: EcrMirror) {}
+  constructor(private readonly mirror: EcrMirror) { }
 
   public visit(construct: IConstruct) {
     if (construct instanceof codebuild.Project) {

--- a/lib/registry-sync/ecr-mirror.ts
+++ b/lib/registry-sync/ecr-mirror.ts
@@ -224,7 +224,7 @@ export class EcrMirror extends Construct {
  * with ECR equivalents found in the EcrMirror.
  */
 export class EcrMirrorAspect implements IAspect {
-  constructor(private readonly mirror: EcrMirror) { }
+  constructor(private readonly mirror: EcrMirror) {}
 
   public visit(construct: IConstruct) {
     if (construct instanceof codebuild.Project) {

--- a/lib/registry-sync/mirror-source.ts
+++ b/lib/registry-sync/mirror-source.ts
@@ -1,8 +1,8 @@
 import {
-  Construct,
   aws_codebuild as codebuild,
   aws_s3_assets as s3Assets,
-} from 'monocdk';
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 
 export interface MirrorSourceBindOptions {
   /**

--- a/lib/repo.ts
+++ b/lib/repo.ts
@@ -1,8 +1,9 @@
 import {
-  Construct, SecretValue, SecretsManagerSecretOptions,
+  SecretValue, SecretsManagerSecretOptions,
   aws_codebuild as cbuild, aws_codecommit as ccommit,
   aws_codepipeline as cpipeline, aws_codepipeline_actions as cpipeline_actions,
-} from 'monocdk';
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import { ExternalSecret } from './permissions';
 
 export interface IRepo {
@@ -67,7 +68,7 @@ export class CodeCommitRepo implements IRepo {
     return this.repository.repositoryCloneUrlSsh;
   }
 
-  public createBuildSource(_: Construct, _webhook: boolean, options: BuildSourceOptions = { }): cbuild.ISource {
+  public createBuildSource(_: Construct, _webhook: boolean, options: BuildSourceOptions = {}): cbuild.ISource {
     return cbuild.Source.codeCommit({
       repository: this.repository,
       cloneDepth: options.cloneDepth,
@@ -136,7 +137,7 @@ export class GitHubRepo implements IRepo {
     return sourceOutput;
   }
 
-  public createBuildSource(_: Construct, webhook: boolean, options: BuildSourceOptions = { }): cbuild.ISource {
+  public createBuildSource(_: Construct, webhook: boolean, options: BuildSourceOptions = {}): cbuild.ISource {
     if (options.branch && options.branches) {
       throw new Error('Specify at most one of \'branch\' and \'branches\'');
     }

--- a/lib/repo.ts
+++ b/lib/repo.ts
@@ -68,7 +68,7 @@ export class CodeCommitRepo implements IRepo {
     return this.repository.repositoryCloneUrlSsh;
   }
 
-  public createBuildSource(_: Construct, _webhook: boolean, options: BuildSourceOptions = {}): cbuild.ISource {
+  public createBuildSource(_: Construct, _webhook: boolean, options: BuildSourceOptions = { }): cbuild.ISource {
     return cbuild.Source.codeCommit({
       repository: this.repository,
       cloneDepth: options.cloneDepth,
@@ -137,7 +137,7 @@ export class GitHubRepo implements IRepo {
     return sourceOutput;
   }
 
-  public createBuildSource(_: Construct, webhook: boolean, options: BuildSourceOptions = {}): cbuild.ISource {
+  public createBuildSource(_: Construct, webhook: boolean, options: BuildSourceOptions = { }): cbuild.ISource {
     if (options.branch && options.branches) {
       throw new Error('Specify at most one of \'branch\' and \'branches\'');
     }

--- a/lib/shellable.ts
+++ b/lib/shellable.ts
@@ -345,7 +345,7 @@ export class Shellable extends Construct {
       return undefined;
     }
 
-    const out: { [key: string]: string } = {};
+    const out: { [key: string]: string } = { };
     Object.entries(environmentSecrets ?? {}).forEach(([name, secretArn]) => {
       const secret = aws_secretsmanager.Secret.fromSecretCompleteArn(this, `${name}SecretFromArn`, secretArn);
       out[name] = secret.secretName;

--- a/lib/shellable.ts
+++ b/lib/shellable.ts
@@ -1,11 +1,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import {
-  Construct, Duration,
+  Duration,
   aws_cloudwatch as cloudwatch, aws_codebuild as cbuild,
   aws_codepipeline as cpipeline, aws_codepipeline_actions as cpipeline_actions,
   aws_iam as iam, aws_s3_assets as assets, aws_secretsmanager, aws_ssm,
-} from 'monocdk';
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import { BuildSpec } from './build-spec';
 import { renderEnvironmentVariables } from './util';
 
@@ -258,7 +259,7 @@ export class Shellable extends Construct {
       path: props.scriptDirectory,
     });
 
-    this.outputArtifactName = `Artifact_${this.node.uniqueId}`;
+    this.outputArtifactName = `Artifact_${this.node.addr}`;
     if (this.outputArtifactName.length > 100) {
       throw new Error(`Whoops, too long: ${this.outputArtifactName}`);
     }
@@ -305,7 +306,7 @@ export class Shellable extends Construct {
     });
 
     if (props.assumeRole) {
-      this.role.addToPolicy(new iam.PolicyStatement({
+      this.role.addToPrincipalPolicy(new iam.PolicyStatement({
         actions: ['sts:AssumeRole'],
         resources: [props.assumeRole.roleArn],
       }));
@@ -344,7 +345,7 @@ export class Shellable extends Construct {
       return undefined;
     }
 
-    const out: { [key: string]: string } = { };
+    const out: { [key: string]: string } = {};
     Object.entries(environmentSecrets ?? {}).forEach(([name, secretArn]) => {
       const secret = aws_secretsmanager.Secret.fromSecretCompleteArn(this, `${name}SecretFromArn`, secretArn);
       out[name] = secret.secretName;

--- a/lib/signing-key.ts
+++ b/lib/signing-key.ts
@@ -1,4 +1,5 @@
-import { Construct, aws_iam as iam, aws_kms as kms } from 'monocdk';
+import { aws_iam as iam, aws_kms as kms } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 import { OpenPGPKeyPair } from './open-pgp-key-pair';
 
 
@@ -43,7 +44,7 @@ export class OpenPgpKey extends Construct {
   constructor(parent: Construct, name: string, props: SigningKeyProps) {
     super(parent, name);
 
-    this.scope = props.secretName || this.node.uniqueId;
+    this.scope = props.secretName || this.node.addr;
     const secretName = `${this.scope}/SigningKey`;
 
     this.key = new kms.Key(this, 'Key', {

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,7 +1,7 @@
 import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
-import { aws_codebuild as cbuild } from 'monocdk';
+import { aws_codebuild as cbuild } from 'aws-cdk-lib';
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "scripts": {
     "build": "npx projen build",
     "bump": "npx projen bump",
+    "bundle": "npx projen bundle",
+    "bundle:lib/chime-notifier/handler/notifier-handler": "npx projen bundle:lib/chime-notifier/handler/notifier-handler",
+    "bundle:lib/chime-notifier/handler/notifier-handler:watch": "npx projen bundle:lib/chime-notifier/handler/notifier-handler:watch",
     "clobber": "npx projen clobber",
     "compile": "npx projen compile",
     "compile:custom-resource-handlers": "npx projen compile:custom-resource-handlers",
@@ -34,36 +37,35 @@
     "organization": false
   },
   "devDependencies": {
-    "@monocdk-experiment/assert": "^1.135.0",
-    "@types/aws-lambda": "^8.10.87",
-    "@types/jest": "^27.0.3",
-    "@types/node": "^14.17.0",
+    "@types/aws-lambda": "^8.10.89",
+    "@types/jest": "*",
+    "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk": "^1.135.0",
-    "aws-sdk": "^2.1046.0",
-    "constructs": "^3.3.165",
-    "esbuild": "^0.14.3",
+    "aws-cdk": "^2.3.0",
+    "aws-cdk-lib": "^2.3.0",
+    "aws-sdk": "^2.1048.0",
+    "constructs": "^10.0.15",
+    "esbuild": "^0.14.8",
     "eslint": "^8",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-import": "^2.25.3",
-    "jest": "^27.4.4",
+    "jest": "^27.4.5",
     "jest-create-mock-instance": "^2.0.0",
     "jest-junit": "^13",
     "json-schema": "^0.4.0",
-    "monocdk": "^1.135.0",
     "node-ical": "^0.14.1",
     "npm-check-updates": "^12",
-    "projen": "^0.40.9",
+    "projen": "^0.46.3",
     "rrule": "^2.6.8",
     "standard-version": "^9",
-    "ts-jest": "^27.1.1",
-    "typescript": "~4.5.3"
+    "ts-jest": "^27.1.2",
+    "typescript": "^4.5.4"
   },
   "peerDependencies": {
-    "constructs": "^3.3.165",
-    "monocdk": "^1.135.0"
+    "aws-cdk-lib": "^2.3.0",
+    "constructs": "^10.0.15"
   },
   "dependencies": {
     "changelog-parser": "^2.8.0"
@@ -75,6 +77,9 @@
     "continuous-delivery",
     "continuous-integration"
   ],
+  "engines": {
+    "node": ">= 14.17.0"
+  },
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
   "scripts": {
     "build": "npx projen build",
     "bump": "npx projen bump",
-    "bundle": "npx projen bundle",
-    "bundle:lib/chime-notifier/handler/notifier-handler": "npx projen bundle:lib/chime-notifier/handler/notifier-handler",
-    "bundle:lib/chime-notifier/handler/notifier-handler:watch": "npx projen bundle:lib/chime-notifier/handler/notifier-handler:watch",
     "clobber": "npx projen clobber",
     "compile": "npx projen compile",
     "compile:custom-resource-handlers": "npx projen compile:custom-resource-handlers",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,28 +2,28 @@
 # yarn lockfile v1
 
 
-"@aws-cdk/cfnspec@1.135.0":
-  version "1.135.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.135.0.tgz#85e6ba02295b0ff21c38e42daf5c8fe5f8549998"
-  integrity sha512-mp4q7qpaPwnEMY3PUXJeMXItvAgftaptcibsG97EQ9twQFLZBElyGADN/YWMBA1oXmDInx3AS4M73yZYhYFydQ==
+"@aws-cdk/cfnspec@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-2.3.0.tgz#e9cd449b7afd0a20c97c489a9fcc26668f02b8f9"
+  integrity sha512-RMFCR1Hu16XXG4o3ZU43IadbRVTx9iU23cD7308sfhryx2cfG4AeguHO2Md4ENrDtpL5nRa7N3LNeFi1+kBJUQ==
   dependencies:
     fs-extra "^9.1.0"
     md5 "^2.3.0"
 
-"@aws-cdk/cloud-assembly-schema@1.135.0":
-  version "1.135.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.135.0.tgz#871519b39066675fe304a8c6ffe6e3c10062a91d"
-  integrity sha512-Xp2nBwiPfkOjN+rxtuAfQ8DviNGSr6k6vzh65U6b25oqTAR8qvrDDGJcGMkRkePuIUlXTyYnbbbxoE1c+iM/xg==
+"@aws-cdk/cloud-assembly-schema@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-2.3.0.tgz#51822f5a5c4b9f2254edf7972c1b34cfce1d014f"
+  integrity sha512-mJ7mqJAl4U8lQln6rVf1jWjan5rBL4A77OrgnE/t7BnLsLhGPrrNmhReWu3xzFZfLrtptBxRRuAiDAdbDHSAXQ==
   dependencies:
     jsonschema "^1.4.0"
     semver "^7.3.5"
 
-"@aws-cdk/cloudformation-diff@1.135.0":
-  version "1.135.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.135.0.tgz#97d03185703958fb19055cc2e1ab37ee123dae8d"
-  integrity sha512-cItLmKaCoj70g2tSC1X495CAZJUZAhXXh3olHwmYlAGRu/i941vz4z/DGLgmywaybnqKYpkk9XDGvvVPovG58g==
+"@aws-cdk/cloudformation-diff@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-2.3.0.tgz#19cf7aea0ea2831dd61265a9940964adce125b51"
+  integrity sha512-GzOENR0C9CP0QyZDF41GgBUyaNKaGZKcNjX2tdEDvGxx8KzOJ9sPEUIfrwCI1CYmRO16mInAepkwAyK9PvMzkQ==
   dependencies:
-    "@aws-cdk/cfnspec" "1.135.0"
+    "@aws-cdk/cfnspec" "2.3.0"
     "@types/node" "^10.17.60"
     colors "^1.4.0"
     diff "^5.0.0"
@@ -31,32 +31,60 @@
     string-width "^4.2.3"
     table "^6.7.5"
 
-"@aws-cdk/cx-api@1.135.0":
-  version "1.135.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.135.0.tgz#8555a2d7136c7b6533878e4c6934afb21edc798b"
-  integrity sha512-ubd7yFZ4nyuLnc70/ht8kIqwzyqh2+V8KxFg5HCUNApM61XzaHr5X/VgSpGSSNXMW7orJbl09SR/Y4e6kzBvkA==
+"@aws-cdk/cx-api@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-2.3.0.tgz#7d99b760df370ee7b5146a57dd8efbbfcb345588"
+  integrity sha512-456IENunPz6v8uIBi5/pntxJJiLUeM4WQFJqxTYwMS7aRLCi0Ug8JYQPbBcUyNgOKr9POLSLy5XnxEsxue3j8w==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.135.0"
+    "@aws-cdk/cloud-assembly-schema" "2.3.0"
     semver "^7.3.5"
 
-"@aws-cdk/region-info@1.135.0":
-  version "1.135.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.135.0.tgz#becbb192099f8a4ceef9a904bb672735825937c1"
-  integrity sha512-tIZn0/l6T+RXMKyGoke68UTQ7zt3xpqiH3myY56MHsEKcos3tn3pM3+JsXFZ/Yo2DfwKsAiY5rPd0qMk46Jj7A==
+"@aws-cdk/region-info@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-2.3.0.tgz#e121bcbfb23503cf69adfae90313267b0fe95854"
+  integrity sha512-Xx4Sc5c5+o7hmLhCbhmSVWEDi5FXRp+ppjzrY8ig6zpt8ShG/VxJ8IukTJhFAh3wW2yoO18ASYp1DLIJYtMUfw==
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
+  integrity sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==
+  dependencies:
+    "@babel/highlight" "^7.14.5"
+
+"@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.0.tgz#0dfc80309beec8411e65e706461c408b0bb9b431"
   integrity sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==
   dependencies:
     "@babel/highlight" "^7.16.0"
 
-"@babel/compat-data@^7.16.0":
+"@babel/compat-data@^7.15.0", "@babel/compat-data@^7.16.0":
   version "7.16.4"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.16.4.tgz#081d6bbc336ec5c2435c6346b2ae1fb98b5ac68e"
   integrity sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==
 
-"@babel/core@^7.1.0", "@babel/core@^7.12.3", "@babel/core@^7.7.2", "@babel/core@^7.7.5":
+"@babel/core@^7.1.0", "@babel/core@^7.7.5":
+  version "7.15.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.15.5.tgz#f8ed9ace730722544609f90c9bb49162dc3bf5b9"
+  integrity sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.15.4"
+    "@babel/helper-compilation-targets" "^7.15.4"
+    "@babel/helper-module-transforms" "^7.15.4"
+    "@babel/helpers" "^7.15.4"
+    "@babel/parser" "^7.15.5"
+    "@babel/template" "^7.15.4"
+    "@babel/traverse" "^7.15.4"
+    "@babel/types" "^7.15.4"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+    source-map "^0.5.0"
+
+"@babel/core@^7.12.3":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.16.0.tgz#c4ff44046f5fe310525cc9eb4ef5147f0c5374d4"
   integrity sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==
@@ -77,7 +105,37 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/generator@^7.16.0", "@babel/generator@^7.7.2":
+"@babel/core@^7.7.2":
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.16.5.tgz#924aa9e1ae56e1e55f7184c8bf073a50d8677f5c"
+  integrity sha512-wUcenlLzuWMZ9Zt8S0KmFwGlH6QKRh3vsm/dhDA3CHkiTA45YuG1XkHRcNRl73EFPXDp/d5kVOU0/y7x2w6OaQ==
+  dependencies:
+    "@babel/code-frame" "^7.16.0"
+    "@babel/generator" "^7.16.5"
+    "@babel/helper-compilation-targets" "^7.16.3"
+    "@babel/helper-module-transforms" "^7.16.5"
+    "@babel/helpers" "^7.16.5"
+    "@babel/parser" "^7.16.5"
+    "@babel/template" "^7.16.0"
+    "@babel/traverse" "^7.16.5"
+    "@babel/types" "^7.16.0"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.15.4.tgz#85acb159a267ca6324f9793986991ee2022a05b0"
+  integrity sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==
+  dependencies:
+    "@babel/types" "^7.15.4"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.16.0.tgz#d40f3d1d5075e62d3500bccb67f3daa8a95265b2"
   integrity sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==
@@ -86,7 +144,26 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/helper-compilation-targets@^7.16.0":
+"@babel/generator@^7.16.5", "@babel/generator@^7.7.2":
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.16.5.tgz#26e1192eb8f78e0a3acaf3eede3c6fc96d22bedf"
+  integrity sha512-kIvCdjZqcdKqoDbVVdt5R99icaRtrtYhYK/xux5qiWCBmfdvEYMFZ68QCrpE5cbFM1JsuArUNs1ZkuKtTtUcZA==
+  dependencies:
+    "@babel/types" "^7.16.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/helper-compilation-targets@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz#cf6d94f30fbefc139123e27dd6b02f65aeedb7b9"
+  integrity sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==
+  dependencies:
+    "@babel/compat-data" "^7.15.0"
+    "@babel/helper-validator-option" "^7.14.5"
+    browserslist "^4.16.6"
+    semver "^6.3.0"
+
+"@babel/helper-compilation-targets@^7.16.0", "@babel/helper-compilation-targets@^7.16.3":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz#5b480cd13f68363df6ec4dc8ac8e2da11363cbf0"
   integrity sha512-vKsoSQAyBmxS35JUOOt+07cLc6Nk/2ljLIHwmq2/NM6hdioUaqEXq/S+nXvbvXbZkNDlWOymPanJGOc4CBjSJA==
@@ -95,6 +172,22 @@
     "@babel/helper-validator-option" "^7.14.5"
     browserslist "^4.17.5"
     semver "^6.3.0"
+
+"@babel/helper-environment-visitor@^7.16.5":
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.5.tgz#f6a7f38b3c6d8b07c88faea083c46c09ef5451b8"
+  integrity sha512-ODQyc5AnxmZWm/R2W7fzhamOk1ey8gSguo5SGvF0zcB3uUzRpTRmM/jmLSm9bDMyPlvbyJ+PwPEK0BWIoZ9wjg==
+  dependencies:
+    "@babel/types" "^7.16.0"
+
+"@babel/helper-function-name@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz#845744dafc4381a4a5fb6afa6c3d36f98a787ebc"
+  integrity sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.15.4"
+    "@babel/template" "^7.15.4"
+    "@babel/types" "^7.15.4"
 
 "@babel/helper-function-name@^7.16.0":
   version "7.16.0"
@@ -105,12 +198,19 @@
     "@babel/template" "^7.16.0"
     "@babel/types" "^7.16.0"
 
-"@babel/helper-get-function-arity@^7.16.0":
+"@babel/helper-get-function-arity@^7.15.4", "@babel/helper-get-function-arity@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz#0088c7486b29a9cb5d948b1a1de46db66e089cfa"
   integrity sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==
   dependencies:
     "@babel/types" "^7.16.0"
+
+"@babel/helper-hoist-variables@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz#09993a3259c0e918f99d104261dfdfc033f178df"
+  integrity sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==
+  dependencies:
+    "@babel/types" "^7.15.4"
 
 "@babel/helper-hoist-variables@^7.16.0":
   version "7.16.0"
@@ -126,12 +226,33 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
-"@babel/helper-module-imports@^7.16.0":
+"@babel/helper-member-expression-to-functions@^7.16.5":
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.5.tgz#1bc9f7e87354e86f8879c67b316cb03d3dc2caab"
+  integrity sha512-7fecSXq7ZrLE+TWshbGT+HyCLkxloWNhTbU2QM1NTI/tDqyf0oZiMcEfYtDuUDCo528EOlt39G1rftea4bRZIw==
+  dependencies:
+    "@babel/types" "^7.16.0"
+
+"@babel/helper-module-imports@^7.15.4", "@babel/helper-module-imports@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz#90538e60b672ecf1b448f5f4f5433d37e79a3ec3"
   integrity sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==
   dependencies:
     "@babel/types" "^7.16.0"
+
+"@babel/helper-module-transforms@^7.15.4":
+  version "7.15.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.15.7.tgz#7da80c8cbc1f02655d83f8b79d25866afe50d226"
+  integrity sha512-ZNqjjQG/AuFfekFTY+7nY4RgBSklgTu970c7Rj3m/JOhIu5KPBUuTA9AY6zaKcUvk4g6EbDXdBnhi35FAssdSw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.15.4"
+    "@babel/helper-replace-supers" "^7.15.4"
+    "@babel/helper-simple-access" "^7.15.4"
+    "@babel/helper-split-export-declaration" "^7.15.4"
+    "@babel/helper-validator-identifier" "^7.15.7"
+    "@babel/template" "^7.15.4"
+    "@babel/traverse" "^7.15.4"
+    "@babel/types" "^7.15.6"
 
 "@babel/helper-module-transforms@^7.16.0":
   version "7.16.0"
@@ -147,6 +268,20 @@
     "@babel/traverse" "^7.16.0"
     "@babel/types" "^7.16.0"
 
+"@babel/helper-module-transforms@^7.16.5":
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.16.5.tgz#530ebf6ea87b500f60840578515adda2af470a29"
+  integrity sha512-CkvMxgV4ZyyioElFwcuWnDCcNIeyqTkCm9BxXZi73RR1ozqlpboqsbGUNvRTflgZtFbbJ1v5Emvm+lkjMYY/LQ==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.16.5"
+    "@babel/helper-module-imports" "^7.16.0"
+    "@babel/helper-simple-access" "^7.16.0"
+    "@babel/helper-split-export-declaration" "^7.16.0"
+    "@babel/helper-validator-identifier" "^7.15.7"
+    "@babel/template" "^7.16.0"
+    "@babel/traverse" "^7.16.5"
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-optimise-call-expression@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz#cecdb145d70c54096b1564f8e9f10cd7d193b338"
@@ -159,6 +294,22 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
   integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
 
+"@babel/helper-plugin-utils@^7.16.5":
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.5.tgz#afe37a45f39fce44a3d50a7958129ea5b1a5c074"
+  integrity sha512-59KHWHXxVA9K4HNF4sbHCf+eJeFe0Te/ZFGqBT4OjXhrwvA04sGfaEGsVTdsjoszq0YTP49RC9UKe5g8uN2RwQ==
+
+"@babel/helper-replace-supers@^7.15.4":
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.16.5.tgz#96d3988bd0ab0a2d22c88c6198c3d3234ca25326"
+  integrity sha512-ao3seGVa/FZCMCCNDuBcqnBFSbdr8N2EW35mzojx3TwfIbdPmNK+JV6+2d5bR0Z71W5ocLnQp9en/cTF7pBJiQ==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.16.5"
+    "@babel/helper-member-expression-to-functions" "^7.16.5"
+    "@babel/helper-optimise-call-expression" "^7.16.0"
+    "@babel/traverse" "^7.16.5"
+    "@babel/types" "^7.16.0"
+
 "@babel/helper-replace-supers@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz#73055e8d3cf9bcba8ddb55cad93fedc860f68f17"
@@ -169,12 +320,19 @@
     "@babel/traverse" "^7.16.0"
     "@babel/types" "^7.16.0"
 
-"@babel/helper-simple-access@^7.16.0":
+"@babel/helper-simple-access@^7.15.4", "@babel/helper-simple-access@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz#21d6a27620e383e37534cf6c10bba019a6f90517"
   integrity sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==
   dependencies:
     "@babel/types" "^7.16.0"
+
+"@babel/helper-split-export-declaration@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz#aecab92dcdbef6a10aa3b62ab204b085f776e257"
+  integrity sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==
+  dependencies:
+    "@babel/types" "^7.15.4"
 
 "@babel/helper-split-export-declaration@^7.16.0":
   version "7.16.0"
@@ -183,7 +341,7 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
-"@babel/helper-validator-identifier@^7.15.7":
+"@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.9", "@babel/helper-validator-identifier@^7.15.7":
   version "7.15.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
   integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
@@ -192,6 +350,15 @@
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
   integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
+
+"@babel/helpers@^7.15.4", "@babel/helpers@^7.16.5":
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.16.5.tgz#29a052d4b827846dd76ece16f565b9634c554ebd"
+  integrity sha512-TLgi6Lh71vvMZGEkFuIxzaPsyeYCHQ5jJOOX1f0xXn0uciFuE8cEk0wyBquMcCxBXZ5BJhE2aUB7pnWTD150Tw==
+  dependencies:
+    "@babel/template" "^7.16.0"
+    "@babel/traverse" "^7.16.5"
+    "@babel/types" "^7.16.0"
 
 "@babel/helpers@^7.16.0":
   version "7.16.3"
@@ -202,6 +369,15 @@
     "@babel/traverse" "^7.16.3"
     "@babel/types" "^7.16.0"
 
+"@babel/highlight@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
+  integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.5"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/highlight@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.0.tgz#6ceb32b2ca4b8f5f361fb7fd821e3fddf4a1725a"
@@ -211,10 +387,20 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.16.0", "@babel/parser@^7.16.3", "@babel/parser@^7.7.2":
+"@babel/parser@^7.1.0", "@babel/parser@^7.15.4", "@babel/parser@^7.15.5":
+  version "7.15.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.7.tgz#0c3ed4a2eb07b165dfa85b3cc45c727334c4edae"
+  integrity sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==
+
+"@babel/parser@^7.14.7", "@babel/parser@^7.16.3":
   version "7.16.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.4.tgz#d5f92f57cf2c74ffe9b37981c0e72fee7311372e"
   integrity sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==
+
+"@babel/parser@^7.16.0", "@babel/parser@^7.16.5", "@babel/parser@^7.7.2":
+  version "7.16.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.6.tgz#8f194828193e8fa79166f34a4b4e52f3e769a314"
+  integrity sha512-Gr86ujcNuPDnNOY8mi383Hvi8IYrJVJYuf3XcuBM/Dgd+bINn/7tHqsj+tKkoreMbmGsFLsltI/JJd8fOFWGDQ==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -301,13 +487,22 @@
     "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-syntax-typescript@^7.7.2":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.0.tgz#2feeb13d9334cc582ea9111d3506f773174179bb"
-  integrity sha512-Xv6mEXqVdaqCBfJFyeab0fH2DnUoMsDmhamxsSi4j8nLd4Vtw213WMJr55xxqipC/YVWyPY3K0blJncPYji+dQ==
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.5.tgz#f47a33e4eee38554f00fb6b2f894fa1f5649b0b3"
+  integrity sha512-/d4//lZ1Vqb4mZ5xTep3dDK888j7BGM/iKqBmndBaoYAFPlPKrGU608VVBz5JeyAb6YQDjRu1UKqj86UhwWVgw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/helper-plugin-utils" "^7.16.5"
 
-"@babel/template@^7.16.0", "@babel/template@^7.3.3":
+"@babel/template@^7.15.4", "@babel/template@^7.3.3":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.15.4.tgz#51898d35dcf3faa670c4ee6afcfd517ee139f194"
+  integrity sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/parser" "^7.15.4"
+    "@babel/types" "^7.15.4"
+
+"@babel/template@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.0.tgz#d16a35ebf4cd74e202083356fab21dd89363ddd6"
   integrity sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==
@@ -316,7 +511,22 @@
     "@babel/parser" "^7.16.0"
     "@babel/types" "^7.16.0"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.16.0", "@babel/traverse@^7.16.3", "@babel/traverse@^7.7.2":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.15.4.tgz#ff8510367a144bfbff552d9e18e28f3e2889c22d"
+  integrity sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.15.4"
+    "@babel/helper-function-name" "^7.15.4"
+    "@babel/helper-hoist-variables" "^7.15.4"
+    "@babel/helper-split-export-declaration" "^7.15.4"
+    "@babel/parser" "^7.15.4"
+    "@babel/types" "^7.15.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.16.0", "@babel/traverse@^7.16.3":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.16.3.tgz#f63e8a938cc1b780f66d9ed3c54f532ca2d14787"
   integrity sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==
@@ -331,7 +541,31 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.16.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
+"@babel/traverse@^7.16.5", "@babel/traverse@^7.7.2":
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.16.5.tgz#d7d400a8229c714a59b87624fc67b0f1fbd4b2b3"
+  integrity sha512-FOCODAzqUMROikDYLYxl4nmwiLlu85rNqBML/A5hKRVXG2LV8d0iMqgPzdYTcIpjZEBB7D6UDU9vxRZiriASdQ==
+  dependencies:
+    "@babel/code-frame" "^7.16.0"
+    "@babel/generator" "^7.16.5"
+    "@babel/helper-environment-visitor" "^7.16.5"
+    "@babel/helper-function-name" "^7.16.0"
+    "@babel/helper-hoist-variables" "^7.16.0"
+    "@babel/helper-split-export-declaration" "^7.16.0"
+    "@babel/parser" "^7.16.5"
+    "@babel/types" "^7.16.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/types@^7.0.0", "@babel/types@^7.15.4", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
+  version "7.15.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.15.6.tgz#99abdc48218b2881c058dd0a7ab05b99c9be758f"
+  integrity sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.9"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.15.6", "@babel/types@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.16.0.tgz#db3b313804f96aadd0b776c4823e127ad67289ba"
   integrity sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
@@ -421,15 +655,15 @@
     jest-util "^27.4.2"
     slash "^3.0.0"
 
-"@jest/core@^27.4.4":
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.4.4.tgz#f2ba293235ca23fb48b4b923ccfe67c17e791a92"
-  integrity sha512-xBNPVqYAdAiAMXnb4ugx9Cdmr0S52lBsLbQMR/sGBRO0810VSPKiuSDtuup6qdkK1e9vxbv3KK3IAP1QFAp8mw==
+"@jest/core@^27.4.5":
+  version "27.4.5"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.4.5.tgz#cae2dc34259782f4866c6606c3b480cce920ed4c"
+  integrity sha512-3tm/Pevmi8bDsgvo73nX8p/WPng6KWlCyScW10FPEoN1HU4pwI83tJ3TsFvi1FfzsjwUlMNEPowgb/rPau/LTQ==
   dependencies:
     "@jest/console" "^27.4.2"
-    "@jest/reporters" "^27.4.4"
+    "@jest/reporters" "^27.4.5"
     "@jest/test-result" "^27.4.2"
-    "@jest/transform" "^27.4.4"
+    "@jest/transform" "^27.4.5"
     "@jest/types" "^27.4.2"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
@@ -438,15 +672,15 @@
     exit "^0.1.2"
     graceful-fs "^4.2.4"
     jest-changed-files "^27.4.2"
-    jest-config "^27.4.4"
-    jest-haste-map "^27.4.4"
+    jest-config "^27.4.5"
+    jest-haste-map "^27.4.5"
     jest-message-util "^27.4.2"
     jest-regex-util "^27.4.0"
-    jest-resolve "^27.4.4"
-    jest-resolve-dependencies "^27.4.4"
-    jest-runner "^27.4.4"
-    jest-runtime "^27.4.4"
-    jest-snapshot "^27.4.4"
+    jest-resolve "^27.4.5"
+    jest-resolve-dependencies "^27.4.5"
+    jest-runner "^27.4.5"
+    jest-runtime "^27.4.5"
+    jest-snapshot "^27.4.5"
     jest-util "^27.4.2"
     jest-validate "^27.4.2"
     jest-watcher "^27.4.2"
@@ -486,15 +720,15 @@
     "@jest/types" "^27.4.2"
     expect "^27.4.2"
 
-"@jest/reporters@^27.4.4":
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.4.4.tgz#9e809829f602cd6e68bd058d1ea528f4b7482365"
-  integrity sha512-ssyJSw9B9Awb1QaxDhIPSs4de1b7SE2kv7tqFehQL13xpn5HUkMYZK/ufTOXiCAnXFOZS+XDl1GaQ/LmJAzI1A==
+"@jest/reporters@^27.4.5":
+  version "27.4.5"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.4.5.tgz#e229acca48d18ea39e805540c1c322b075ae63ad"
+  integrity sha512-3orsG4vi8zXuBqEoy2LbnC1kuvkg1KQUgqNxmxpQgIOQEPeV0onvZu+qDQnEoX8qTQErtqn/xzcnbpeTuOLSiA==
   dependencies:
     "@bcoe/v8-coverage" "^0.2.3"
     "@jest/console" "^27.4.2"
     "@jest/test-result" "^27.4.2"
-    "@jest/transform" "^27.4.4"
+    "@jest/transform" "^27.4.5"
     "@jest/types" "^27.4.2"
     "@types/node" "*"
     chalk "^4.0.0"
@@ -507,10 +741,10 @@
     istanbul-lib-report "^3.0.0"
     istanbul-lib-source-maps "^4.0.0"
     istanbul-reports "^3.0.2"
-    jest-haste-map "^27.4.4"
-    jest-resolve "^27.4.4"
+    jest-haste-map "^27.4.5"
+    jest-resolve "^27.4.5"
     jest-util "^27.4.2"
-    jest-worker "^27.4.4"
+    jest-worker "^27.4.5"
     slash "^3.0.0"
     source-map "^0.6.0"
     string-length "^4.0.1"
@@ -536,20 +770,20 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
-"@jest/test-sequencer@^27.4.4":
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.4.4.tgz#60be14369b2702e42d6042e71b8ab3fc69f5ce68"
-  integrity sha512-mCh+d4JTGTtX7vr13d7q2GHJy33nAobEwtEJ8X3u7R8+0ImVO2eAsQzsLfX8lyvdYHBxYABhqbYuaUNo42/pQw==
+"@jest/test-sequencer@^27.4.5":
+  version "27.4.5"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.4.5.tgz#1d7e026844d343b60d2ca7fd82c579a17b445d7d"
+  integrity sha512-n5woIn/1v+FT+9hniymHPARA9upYUmfi5Pw9ewVwXCDlK4F5/Gkees9v8vdjGdAIJ2MPHLHodiajLpZZanWzEQ==
   dependencies:
     "@jest/test-result" "^27.4.2"
     graceful-fs "^4.2.4"
-    jest-haste-map "^27.4.4"
-    jest-runtime "^27.4.4"
+    jest-haste-map "^27.4.5"
+    jest-runtime "^27.4.5"
 
-"@jest/transform@^27.4.4":
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.4.4.tgz#347e39402730879ba88c6ea6982db0d88640aa78"
-  integrity sha512-7U/nDSrGsGzL7+X8ScNFV71w8u8knJQWSa9C2xsrrKLMOgb+rWuCG4VAyWke/53BU96GnT+Ka81xCAHA5gk6zA==
+"@jest/transform@^27.4.5":
+  version "27.4.5"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.4.5.tgz#3dfe2e3680cd4aa27356172bf25617ab5b94f195"
+  integrity sha512-PuMet2UlZtlGzwc6L+aZmR3I7CEBpqadO03pU40l2RNY2fFJ191b9/ITB44LNOhVtsyykx0OZvj0PCyuLm7Eew==
   dependencies:
     "@babel/core" "^7.1.0"
     "@jest/types" "^27.4.2"
@@ -558,7 +792,7 @@
     convert-source-map "^1.4.0"
     fast-json-stable-stringify "^2.0.0"
     graceful-fs "^4.2.4"
-    jest-haste-map "^27.4.4"
+    jest-haste-map "^27.4.5"
     jest-regex-util "^27.4.0"
     jest-util "^27.4.2"
     micromatch "^4.0.4"
@@ -585,13 +819,6 @@
   dependencies:
     chalk "^4.1.2"
     semver "^7.3.5"
-
-"@monocdk-experiment/assert@^1.135.0":
-  version "1.135.0"
-  resolved "https://registry.yarnpkg.com/@monocdk-experiment/assert/-/assert-1.135.0.tgz#2b2867ab17ae3eddc66413effefb73c01a3f5917"
-  integrity sha512-2rOayyBRhGQarj3uu/wn8B0WcFA4j3pipe/hogbXcVIOxlo2NxeiY4F9h4kUgNbciHzXf6gt4E1xJhw28034Iw==
-  dependencies:
-    "@aws-cdk/cloudformation-diff" "1.135.0"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -734,12 +961,23 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@types/aws-lambda@^8.10.87":
-  version "8.10.87"
-  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.87.tgz#5e90af2d4ffb41d3bf9c97080a5c4700ddf06436"
-  integrity sha512-fMYSgnIjFsTM3huCzqNvZm9gH4kFY5yIEOKYj9VtTG13TYd+wwweTbYAAO8OclcTbpezK+VsHNWIyHiAHgVCJg==
+"@types/aws-lambda@^8.10.89":
+  version "8.10.89"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.89.tgz#22617ecc1eef9571abebb50c947553362da6051b"
+  integrity sha512-jwtSuEZj4rY4R2pAEOXi+RutS8RWbwMzoGlRVukdyOpnfqA/XPkAf8QoGWmg4o/UaNpQ8Mj0Xhkp5SZ1t/Zq4Q==
 
-"@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
+"@types/babel__core@^7.0.0":
+  version "7.1.16"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.16.tgz#bc12c74b7d65e82d29876b5d0baf5c625ac58702"
+  integrity sha512-EAEHtisTMM+KaKwfWdC3oyllIqswlznXCIVCt7/oRNrh+DhgT4UEBNC/jlADNjvw7UnfbcdkGQcPVZ1xYiLcrQ==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
+"@types/babel__core@^7.1.14":
   version "7.1.17"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.17.tgz#f50ac9d20d64153b510578d84f9643f9a3afbe64"
   integrity sha512-6zzkezS9QEIL8yCBvXWxPTJPNuMeECJVxSOhxNY/jfq9LxOTHivaYTqr37n9LknWWRTIkzqH2UilS5QFvfa90A==
@@ -798,7 +1036,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^27.0.3":
+"@types/jest@*":
   version "27.0.3"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.3.tgz#0cf9dfe9009e467f70a342f0f94ead19842a783a"
   integrity sha512-cmmwv9t7gBYt7hNKH5Spu7Kuu/DotGa+Ff+JGRKZ4db5eh8PnKS4LuebJ3YLUoyOyIHraTGyULn23YtEAm0VSg==
@@ -831,10 +1069,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
-"@types/node@^14.17.0":
-  version "14.18.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.0.tgz#98df2397f6936bfbff4f089e40e06fa5dd88d32a"
-  integrity sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ==
+"@types/node@^14":
+  version "14.18.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.2.tgz#00fe4d1686d5f6cf3a2f2e9a0eef42594d06abfc"
+  integrity sha512-fqtSN5xn/bBzDxMT77C1rJg6CsH/R49E7qsGuvdPJa20HtV5zSTuLJPNfnlyVH3wauKnkHdLggTVkOW/xP9oQg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -864,12 +1102,12 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^5":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.6.0.tgz#efd8668b3d6627c46ce722c2afe813928fe120a0"
-  integrity sha512-MIbeMy5qfLqtgs1hWd088k1hOuRsN9JrHUPwVVKCD99EOUqScd7SrwoZl4Gso05EAP9w1kvLWUVGJOVpRPkDPA==
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.8.0.tgz#52cd9305ceef98a5333f9492d519e6c6c7fe7d43"
+  integrity sha512-spu1UW7QuBn0nJ6+psnfCc3iVoQAifjKORgBngKOmC8U/1tbe2YJMzYQqDGYB4JCss7L8+RM2kKLb1B1Aw9BNA==
   dependencies:
-    "@typescript-eslint/experimental-utils" "5.6.0"
-    "@typescript-eslint/scope-manager" "5.6.0"
+    "@typescript-eslint/experimental-utils" "5.8.0"
+    "@typescript-eslint/scope-manager" "5.8.0"
     debug "^4.3.2"
     functional-red-black-tree "^1.0.1"
     ignore "^5.1.8"
@@ -877,60 +1115,60 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.6.0.tgz#f3a5960f2004abdcac7bb81412bafc1560841c23"
-  integrity sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==
+"@typescript-eslint/experimental-utils@5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.8.0.tgz#0916ffe98d34b3c95e3652efa0cace61a7b25728"
+  integrity sha512-KN5FvNH71bhZ8fKtL+lhW7bjm7cxs1nt+hrDZWIqb6ViCffQcWyLunGrgvISgkRojIDcXIsH+xlFfI4RCDA0xA==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.6.0"
-    "@typescript-eslint/types" "5.6.0"
-    "@typescript-eslint/typescript-estree" "5.6.0"
+    "@typescript-eslint/scope-manager" "5.8.0"
+    "@typescript-eslint/types" "5.8.0"
+    "@typescript-eslint/typescript-estree" "5.8.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
 "@typescript-eslint/parser@^5":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.6.0.tgz#11677324659641400d653253c03dcfbed468d199"
-  integrity sha512-YVK49NgdUPQ8SpCZaOpiq1kLkYRPMv9U5gcMrywzI8brtwZjr/tG3sZpuHyODt76W/A0SufNjYt9ZOgrC4tLIQ==
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.8.0.tgz#b39970b21c1d7bc4a6018507fb29b380328d2587"
+  integrity sha512-Gleacp/ZhRtJRYs5/T8KQR3pAQjQI89Dn/k+OzyCKOsLiZH2/Vh60cFBTnFsHNI6WAD+lNUo/xGZ4NeA5u0Ipw==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.6.0"
-    "@typescript-eslint/types" "5.6.0"
-    "@typescript-eslint/typescript-estree" "5.6.0"
+    "@typescript-eslint/scope-manager" "5.8.0"
+    "@typescript-eslint/types" "5.8.0"
+    "@typescript-eslint/typescript-estree" "5.8.0"
     debug "^4.3.2"
 
-"@typescript-eslint/scope-manager@5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.6.0.tgz#9dd7f007dc8f3a34cdff6f79f5eaab27ae05157e"
-  integrity sha512-1U1G77Hw2jsGWVsO2w6eVCbOg0HZ5WxL/cozVSTfqnL/eB9muhb8THsP0G3w+BB5xAHv9KptwdfYFAUfzcIh4A==
+"@typescript-eslint/scope-manager@5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.8.0.tgz#2371095b4fa4c7be6a80b380f4e1b49c715e16f4"
+  integrity sha512-x82CYJsLOjPCDuFFEbS6e7K1QEWj7u5Wk1alw8A+gnJiYwNnDJk0ib6PCegbaPMjrfBvFKa7SxE3EOnnIQz2Gg==
   dependencies:
-    "@typescript-eslint/types" "5.6.0"
-    "@typescript-eslint/visitor-keys" "5.6.0"
+    "@typescript-eslint/types" "5.8.0"
+    "@typescript-eslint/visitor-keys" "5.8.0"
 
-"@typescript-eslint/types@5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.6.0.tgz#745cb1b59daadcc1f32f7be95f0f68accf38afdd"
-  integrity sha512-OIZffked7mXv4mXzWU5MgAEbCf9ecNJBKi+Si6/I9PpTaj+cf2x58h2oHW5/P/yTnPkKaayfjhLvx+crnl5ubA==
+"@typescript-eslint/types@5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.8.0.tgz#e7fa74ec35d9dbe3560d039d3d8734986c3971e0"
+  integrity sha512-LdCYOqeqZWqCMOmwFnum6YfW9F3nKuxJiR84CdIRN5nfHJ7gyvGpXWqL/AaW0k3Po0+wm93ARAsOdzlZDPCcXg==
 
-"@typescript-eslint/typescript-estree@5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.6.0.tgz#dfbb19c9307fdd81bd9c650c67e8397821d7faf0"
-  integrity sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==
+"@typescript-eslint/typescript-estree@5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.8.0.tgz#900469ba9d5a37f4482b014ecce4a5dbb86cb4dd"
+  integrity sha512-srfeZ3URdEcUsSLbkOFqS7WoxOqn8JNil2NSLO9O+I2/Uyc85+UlfpEvQHIpj5dVts7KKOZnftoJD/Fdv0L7nQ==
   dependencies:
-    "@typescript-eslint/types" "5.6.0"
-    "@typescript-eslint/visitor-keys" "5.6.0"
+    "@typescript-eslint/types" "5.8.0"
+    "@typescript-eslint/visitor-keys" "5.8.0"
     debug "^4.3.2"
     globby "^11.0.4"
     is-glob "^4.0.3"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/visitor-keys@5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.6.0.tgz#3e36509e103fe9713d8f035ac977235fd63cb6e6"
-  integrity sha512-1p7hDp5cpRFUyE3+lvA74egs+RWSgumrBpzBCDzfTFv0aQ7lIeay80yU0hIxgAhwQ6PcasW35kaOCyDOv6O/Ng==
+"@typescript-eslint/visitor-keys@5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.8.0.tgz#22d4ed96fe2451135299239feedb9fe1dcec780c"
+  integrity sha512-+HDIGOEMnqbxdAHegxvnOqESUH6RWFRR2b8qxP1W9CZnnYh4Usz6MBL+2KMAgPk/P0o9c1HqnYtwzVH6GTIqug==
   dependencies:
-    "@typescript-eslint/types" "5.6.0"
+    "@typescript-eslint/types" "5.8.0"
     eslint-visitor-keys "^3.0.0"
 
 JSONStream@^1.0.4:
@@ -1195,20 +1433,35 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-aws-cdk@^1.135.0:
-  version "1.135.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.135.0.tgz#b997b33ecf2109bf6286c6eefff37bf125fc78d9"
-  integrity sha512-4T/M0JF7m7Hcolij2a4Sbp5rLxPvKr6noCGtKgPIwaoCvQNOmHRgn/mHy31y6sX8/aPc90wt2Pc/CMPmBof01g==
+aws-cdk-lib@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.3.0.tgz#9592e51f51d012e1e56f851700d1b8e9687eee93"
+  integrity sha512-fVQ7x+ahOmzcy5KCw+EaYp0II3igglJSpi/Rs4OyLrCxa7GBZ4G9iDu0IAPKjppw5IX3UshklmdfkEFP8d1b9w==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.135.0"
-    "@aws-cdk/cloudformation-diff" "1.135.0"
-    "@aws-cdk/cx-api" "1.135.0"
-    "@aws-cdk/region-info" "1.135.0"
+    "@balena/dockerignore" "^1.0.2"
+    case "1.6.3"
+    fs-extra "^9.1.0"
+    ignore "^5.1.9"
+    jsonschema "^1.4.0"
+    minimatch "^3.0.4"
+    punycode "^2.1.1"
+    semver "^7.3.5"
+    yaml "1.10.2"
+
+aws-cdk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-2.3.0.tgz#c8ef1c81f19bab4f8438aa2140b445891f824dc3"
+  integrity sha512-Wol01xLh7mAg8iM7Gd0xlzpA/CNbJELujTjGfZVlKfn2hkACMDhAvk2WHcRX06JF9q1PN9M6cs6K+XHgqdFniA==
+  dependencies:
+    "@aws-cdk/cloud-assembly-schema" "2.3.0"
+    "@aws-cdk/cloudformation-diff" "2.3.0"
+    "@aws-cdk/cx-api" "2.3.0"
+    "@aws-cdk/region-info" "2.3.0"
     "@jsii/check-node" "1.47.0"
     archiver "^5.3.0"
     aws-sdk "^2.979.0"
     camelcase "^6.2.1"
-    cdk-assets "1.135.0"
+    cdk-assets "2.3.0"
     chokidar "^3.5.2"
     colors "^1.4.0"
     decamelize "^5.0.1"
@@ -1226,7 +1479,22 @@ aws-cdk@^1.135.0:
     yaml "1.10.2"
     yargs "^16.2.0"
 
-aws-sdk@^2.1046.0, aws-sdk@^2.848.0, aws-sdk@^2.979.0:
+aws-sdk@^2.1048.0:
+  version "2.1048.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1048.0.tgz#02f2f35e0f51dd4510462e05c7a48fd4649d33f8"
+  integrity sha512-mVwWo+Udiuc/yEZ/DgJQGqOEtfiQjgUdtshx/t6ISe3+jW3TF9hUACwADwx2Sr/fuJyyJ3QD5JYLt5Cw35wQpA==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
+aws-sdk@^2.848.0, aws-sdk@^2.979.0:
   version "2.1046.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1046.0.tgz#9147b0fa1c86acbebd1a061e951ab5012f4499d7"
   integrity sha512-ocwHclMXdIA+NWocUyvp9Ild3/zy2vr5mHp3mTyodf0WU5lzBE8PocCVLSWhMAXLxyia83xv2y5f5AzAcetbqA==
@@ -1248,12 +1516,12 @@ axios@^0.24.0:
   dependencies:
     follow-redirects "^1.14.4"
 
-babel-jest@^27.4.4:
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.4.4.tgz#a012441f8a155df909839543a09510ab3477aa11"
-  integrity sha512-+6RVutZxOQgJkt4svgTHPFtOQlVe9dUg3wrimIAM38pY6hL/nsL8glfFSUjD9jNVjaVjzkCzj6loFFecrjr9Qw==
+babel-jest@^27.4.5:
+  version "27.4.5"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.4.5.tgz#d38bd0be8ea71d8b97853a5fc9f76deeb095c709"
+  integrity sha512-3uuUTjXbgtODmSv/DXO9nZfD52IyC2OYTFaXGRzL0kpykzroaquCrD5+lZNafTvZlnNqZHt5pb0M08qVBZnsnA==
   dependencies:
-    "@jest/transform" "^27.4.4"
+    "@jest/transform" "^27.4.5"
     "@jest/types" "^27.4.2"
     "@types/babel__core" "^7.1.14"
     babel-plugin-istanbul "^6.0.0"
@@ -1367,13 +1635,13 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-browserslist@^4.17.5:
-  version "4.18.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.18.1.tgz#60d3920f25b6860eb917c6c7b185576f4d8b017f"
-  integrity sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==
+browserslist@^4.16.6, browserslist@^4.17.5:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.19.1.tgz#4ac0435b35ab655896c31d53018b6dd5e9e4c9a3"
+  integrity sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==
   dependencies:
-    caniuse-lite "^1.0.30001280"
-    electron-to-chromium "^1.3.896"
+    caniuse-lite "^1.0.30001286"
+    electron-to-chromium "^1.4.17"
     escalade "^3.1.1"
     node-releases "^2.0.1"
     picocolors "^1.0.0"
@@ -1493,28 +1761,33 @@ camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-camelcase@^6.2.0, camelcase@^6.2.1:
+camelcase@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
+  integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
+
+camelcase@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.1.tgz#250fd350cfd555d0d2160b1d51510eaf8326e86e"
   integrity sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==
 
-caniuse-lite@^1.0.30001280:
-  version "1.0.30001286"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz#3e9debad420419618cfdf52dc9b6572b28a8fff6"
-  integrity sha512-zaEMRH6xg8ESMi2eQ3R4eZ5qw/hJiVsO/HlLwniIwErij0JDr9P+8V4dtx1l+kLq6j3yy8l8W4fst1lBnat5wQ==
+caniuse-lite@^1.0.30001286:
+  version "1.0.30001292"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz#4a55f61c06abc9595965cfd77897dc7bc1cdc456"
+  integrity sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==
 
 case@1.6.3, case@^1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
   integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
 
-cdk-assets@1.135.0:
-  version "1.135.0"
-  resolved "https://registry.yarnpkg.com/cdk-assets/-/cdk-assets-1.135.0.tgz#37457915992110394ae7e721df557eb3dc627b5f"
-  integrity sha512-wYQO/QeGm9s4Z8kg00WZGyyPl/JSINqEbBFuRemvS0OMiGQIzVR5sNJ8Xg/P7wp/l64lvsjMhKIft08HQSSHbA==
+cdk-assets@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/cdk-assets/-/cdk-assets-2.3.0.tgz#73a558d835814827cd1b8488977bf5204590379c"
+  integrity sha512-7akSz6aZDRkI2XziQATvmkzB0unRsD/CjJj6c4SIDhZpb467PPncgOBUKuTBzv88j61XGVCrpkfhQQlz8rmFlg==
   dependencies:
-    "@aws-cdk/cloud-assembly-schema" "1.135.0"
-    "@aws-cdk/cx-api" "1.135.0"
+    "@aws-cdk/cloud-assembly-schema" "2.3.0"
+    "@aws-cdk/cx-api" "2.3.0"
     archiver "^5.3.0"
     aws-sdk "^2.848.0"
     glob "^7.2.0"
@@ -1747,10 +2020,10 @@ console-control-strings@^1.0.0, console-control-strings@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-constructs@^3.3.165:
-  version "3.3.165"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.3.165.tgz#7ba4f5ef344ec2ed13357021747f0e412a363d76"
-  integrity sha512-s1O0hXAVDNhwCk07vM7Av9Xek3EUF8LdvVRaFSk+oONp/A5cPGz0fXFJkp0fg9JF34imWr20F2uCggw1t8ozhw==
+constructs@^10.0.15:
+  version "10.0.15"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.0.15.tgz#8463fbf982133f0ea2ffbae4abc94b55b03e029d"
+  integrity sha512-HmEqwXEF4rtgO9UcB+p8CYoA0OdQG/oATyHa/kwTDrqZ3DIRPdnc4I/h87uS7YZYptfgcmgsQTJkqtDd0TJh0w==
 
 conventional-changelog-angular@^5.0.12:
   version "5.0.13"
@@ -2003,10 +2276,10 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
-  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   dependencies:
     ms "2.1.2"
 
@@ -2023,6 +2296,13 @@ debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.2:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
 
 decamelize-keys@^1.1.0:
   version "1.1.0"
@@ -2193,10 +2473,10 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
-electron-to-chromium@^1.3.896:
-  version "1.4.16"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.16.tgz#38ddecc616385e6f101359d1b978c802664157d2"
-  integrity sha512-BQb7FgYwnu6haWLU63/CdVW+9xhmHls3RCQUFiV4lvw3wimEHTVcUk2hkuZo76QhR8nnDdfZE7evJIZqijwPdA==
+electron-to-chromium@^1.4.17:
+  version "1.4.27"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.27.tgz#bfc6e798d8a56a17d658312f4b7ae1a7ca87724f"
+  integrity sha512-uZ95szi3zUbzRDx1zx/xnsCG+2xgZyy57pDOeaeO4r8zx5Dqe8Jv1ti8cunvBwJHVI5LzPuw8umKwZb3WKYxSQ==
 
 emittery@^0.8.1:
   version "0.8.1"
@@ -2286,113 +2566,119 @@ es5-ext@0.8.x:
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.8.2.tgz#aba8d9e1943a895ac96837a62a39b3f55ecd94ab"
   integrity sha1-q6jZ4ZQ6iVrJaDemKjmz9V7NlKs=
 
-esbuild-android-arm64@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.3.tgz#f0fc0a892dd6f2f42baf68f9ac24c9bfcfdaba20"
-  integrity sha512-v/vdnGJiSGWOAXzg422T9qb4S+P3tOaYtc5n3FDR27Bh3/xQDS7PdYz/yY7HhOlVp0eGwWNbPHEi8FcEhXjsuw==
+esbuild-android-arm64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.8.tgz#69324e08ba68c7d9a541e7b825d7235b83e17bd6"
+  integrity sha512-tAEoSHnPBSH0cCAFa/aYs3LPsoTY4SwsP6wDKi4PaelbQYNJjqNpAeweyJ8l98g1D6ZkLyqsHbkYj+209sezkA==
 
-esbuild-darwin-64@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.3.tgz#074268b97df08dc2ea60ddd3c29b05fd93ff63d3"
-  integrity sha512-swY5OtEg6cfWdgc/XEjkBP7wXSyXXeZHEsWMdh1bDiN1D6GmRphk9SgKFKTj+P3ZHhOGIcC1+UdIwHk5bUcOig==
+esbuild-darwin-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.8.tgz#7176b692b9de746ba2f9dd4dd81dc4f1b7670786"
+  integrity sha512-t7p7WzTb+ybiD/irkMt5j/NzB+jY+8yPTsrXk5zCOH1O7DdthRnAUJ7pJPwImdL7jAGRbLtYRxUPgCHs/0qUPw==
 
-esbuild-darwin-arm64@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.3.tgz#72a62c7e5c58a2321f0bb839f1368878d4a5a814"
-  integrity sha512-6i9dXPk8oT87wF6VHmwzSad76eMRU2Rt+GXrwF3Y4DCJgnPssJbabNQ9gurkuEX8M0YnEyJF0d1cR7rpTzcEiA==
+esbuild-darwin-arm64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.8.tgz#59167584e58428877e48e05c4cca58755f843327"
+  integrity sha512-5FeaT2zMUajKnBwUMSsjZev5iA38YHrDmXhkOCwZQIFUvhqojinqCrvv/X7dyxb1987bcY9KGwJ+EwDwd922HQ==
 
-esbuild-freebsd-64@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.3.tgz#63f507254f41ccbab97bb6dce655e7dbc127f351"
-  integrity sha512-WDY5ENsmyceeE+95U3eI+FM8yARY5akWkf21M/x/+v2P5OVsYqCYELglSeAI5Y7bhteCVV3g4i2fRqtkmprdSA==
+esbuild-freebsd-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.8.tgz#00b7d6e00abba9c2eccc9acd576c796333671e9c"
+  integrity sha512-pGHBLSf7ynfyDZXUtbq/GsA2VIwQlWXrUj1AMcE0id47mRdEUM8/1ZuqMGZx63hRnNgtK9zNJ8OIu2c7qq76Qw==
 
-esbuild-freebsd-arm64@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.3.tgz#6520f6c8339df943633586d0d597ac2ee1f1958d"
-  integrity sha512-4BEEGcP0wBzg04pCCWXlgaPuksQHHfwHvYgCIsi+7IsuB17ykt6MHhTkHR5b5pjI/jNtRhPfMsDODUyftQJgvw==
+esbuild-freebsd-arm64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.8.tgz#57f0cd5a1cb37fa2c0e84e780677fe62f1e8c894"
+  integrity sha512-g4GgAnrx6Gh1BjKJjJWgPnOR4tW2FcAx9wFvyUjRsIjB35gT+aAFR+P/zStu5OG9LnbS8Pvjd4wS68QIXk+2dA==
 
-esbuild-linux-32@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.3.tgz#813d7baf2d33675c9264a07b09a26c39d588abb2"
-  integrity sha512-8yhsnjLG/GwCA1RAIndjmCHWViRB2Ol0XeOh2fCXS9qF8tlVrJB7qAiHZpm2vXx+yjOA/bFLTxzU+5pMKqkn5A==
+esbuild-linux-32@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.8.tgz#bbf3e5d3fb30f949030d0c2241ac93a172917d56"
+  integrity sha512-wPfQJadF5vTzriw/B8Ide74PeAJlZW7czNx3NIUHkHlXb+En1SeIqNzl6jG9DuJUl57xD9Ucl9YJFEkFeX8eLg==
 
-esbuild-linux-64@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.3.tgz#6356ff2d2c6ec978eb6e794a8891cc5cfadab3f1"
-  integrity sha512-eNq4aixfbwXHIJq4bQDe+XaSNV1grxqpZYs/zHbp0HGHf6SBNlTI02uyTbYGpIzlXmCEPS9tpPCi7BTU45kcJQ==
+esbuild-linux-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.8.tgz#08631e9e0da613603bcec782f29fecbc6f4596de"
+  integrity sha512-+RNuLk9RhRDL2kG+KTEYl5cIgF6AGLkRnKKWEu9DpCZaickONEqrKyQSVn410Hj105DLdW6qvIXQQHPycJhExg==
 
-esbuild-linux-arm64@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.3.tgz#a289bb67a5207e021d1ac8cae3532771eda473a6"
-  integrity sha512-wPLyRoqoV/tEMQ7M24DpAmCMyKqBmtgZY35w2tXM8X5O5b2Ohi7fkPSmd6ZgLIxZIApWt88toA8RT0S7qoxcOA==
+esbuild-linux-arm64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.8.tgz#206d39c8dfbb7c72aa2f5fc52f7402b5b8a77366"
+  integrity sha512-BtWoKNYul9UoxUvQUSdSrvSmJyFL1sGnNPTSqWCg1wMe4kmc8UY2yVsXSSkKO8N2jtHxlgFyz/XhvNBzEwGVcw==
 
-esbuild-linux-arm@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.3.tgz#b193de64458d4829be18206e58d127296367c189"
-  integrity sha512-YcMvJHAQnWrWKb+eLxN9e/iWUC/3w01UF/RXuMknqOW3prX8UQ63QknWz9/RI8BY/sdrdgPEbSmsTU2jy2cayQ==
+esbuild-linux-arm@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.8.tgz#e28e70420d187f5e403bfa4a72df676d53d707fd"
+  integrity sha512-HIct38SvUAIJbiTwV/PVQroimQo96TGtzRDAEZxTorB4vsAj1r8bd0keXExPU4RH7G0zIqC4loQQpWYL+nH4Vg==
 
-esbuild-linux-mips64le@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.3.tgz#d3c826fc746f1cbf3aea696017b001625ea28b59"
-  integrity sha512-DdmfM5rcuoqjQL3px5MbquAjZWnySB5LdTrg52SSapp0gXMnGcsM6GY2WVta02CMKn5qi7WPVG4WbqTWE++tJw==
+esbuild-linux-mips64le@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.8.tgz#04997ac1a0df794a4d5e04d78015863d48490590"
+  integrity sha512-0DxnCl9XTvaQtsX6Qa+Phr5i9b04INwwSv2RbQ2UWRLoQ/037iaFzbmuhgrcmaGOcRwPkCa+4Qo5EgI01MUgsQ==
 
-esbuild-linux-ppc64le@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.3.tgz#483974c92555eefe86d623145ff5f328074b6c9b"
-  integrity sha512-ujdqryj0m135Ms9yaNDVFAcLeRtyftM/v2v7Osji5zElf2TivSMdFxdrYnYICuHfkm8c8gHg1ncwqitL0r+nnA==
+esbuild-linux-ppc64le@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.8.tgz#1827378feff9702c156047ba118c1f3bd74da67e"
+  integrity sha512-Uzr/OMj97Q0qoWLXCvXCKUY/z1SNI4iSZEuYylM5Nd71HGStL32XWq/MReJ0PYMvUMKKJicKSKw2jWM1uBQ84Q==
 
-esbuild-netbsd-64@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.3.tgz#76442f9d2d6e6dc796d18eb321256ccdc68ead53"
-  integrity sha512-Z/UB9OUdwo1KDJCSGnVueDuKowRZRkduLvRMegHtDBHC3lS5LfZ3RdM1i+4MMN9iafyk8Q9FNcqIXI178ZujvA==
+esbuild-linux-s390x@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.8.tgz#200ac44cda59b81135b325c3a29d016969650876"
+  integrity sha512-vURka7aCA5DrRoOqOn6pXYwFlDSoQ4qnqam8AC0Ikn6tibutuhgar6M3Ek2DCuz9yqd396mngdYr5A8x2TPkww==
 
-esbuild-openbsd-64@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.3.tgz#13b0adfd39e165f0dfd30af3e629c601b1b5fa36"
-  integrity sha512-9I1uoMDeogq3zQuTe3qygmXYjImnvc6rBn51LLbLniQDlfvqHPBMnAZ/5KshwtXXIIMkCwByytDZdiuzRRlTvQ==
+esbuild-netbsd-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.8.tgz#8159d8eae111f80ea6e4cbfa5d4cf658388a72d4"
+  integrity sha512-tjyDak2/pp0VUAhBW6/ueuReMd5qLHNlisXl5pq0Xn0z+kH9urA/t1igm0JassWbdMz123td5ZEQWoD9KbtOAw==
 
-esbuild-sunos-64@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.3.tgz#f8ce1a0c6f165b82d589c7f3de01baf094587fd2"
-  integrity sha512-pldqx/Adxl4V4ymiyKxOOyJmHn6nUIo3wqk2xBx07iDgmL2XTcDDQd7N4U4QGu9LnYN4ZF+8IdOYa3oRRpbjtg==
+esbuild-openbsd-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.8.tgz#2a9498d881a3ab94927c724f34dd1160eef1f3b8"
+  integrity sha512-zAKKV15fIyAuDDga5rQv0lW2ufBWj/OCjqjDBb3dJf5SfoAi/DMIHuzmkKQeDQ+oxt9Rp1D7ZOlOBVflutFTqQ==
 
-esbuild-windows-32@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.3.tgz#f555cbf0fca5974c3c303d9d9ff0d39e08f26916"
-  integrity sha512-AqzvA/KbkC2m3kTXGpljLin3EttRbtoPTfBn6w6n2m9MWkTEbhQbE1ONoOBxhO5tExmyJdL/6B87TJJD5jEFBQ==
+esbuild-sunos-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.8.tgz#2447de7d79848ad528c7d44caab4938eb8f5a0cc"
+  integrity sha512-xV41Wa8imziM/2dbWZjLKQbIETRgo5dE0oc/uPsgaecJhsrdA0VkGa/V432LJSUYv967xHDQdoRRl5tr80+NnQ==
 
-esbuild-windows-64@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.3.tgz#02c9804f9ca5e587ccb8b18e46a00f9237e54689"
-  integrity sha512-HGg3C6113zLGB5hN41PROTnBuoh/arG2lQdOird6xFl9giff1cAfMQOUJUfODKD57dDqHjQ1YGW8gOkg0/IrWw==
+esbuild-windows-32@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.8.tgz#3287281552d7e4c851b3106940ff5826f518043e"
+  integrity sha512-AxpdeLKQSyCZo7MzdOyV4OgEbEJcjnrS/2niAjbHESbjuS5P1DN/5vZoJ/JSWDVa/40OkBuHBhAXMx1HK3UDsg==
 
-esbuild-windows-arm64@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.3.tgz#8bcf737feddde3ccf4d2d6d581b2422b45a9b6e2"
-  integrity sha512-qB2izYu4VpigGnOrAN2Yv7ICYLZWY/AojZtwFfteViDnHgW4jXPYkHQIXTISJbRz25H2cYiv+MfRQYK31RNjlw==
+esbuild-windows-64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.8.tgz#b4052868438b4f17b5c2a908cf344ed2bd267c38"
+  integrity sha512-/3pllNoy8mrz/E1rYalwiwwhzJBrYQhEapwAteHZbFVhGzYuB8F80e8x5eA8dhFHxDiZh1VzK+hREwwSt8UTQA==
 
-esbuild@^0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.3.tgz#38db1d26aaeccc43f478225974538e2c4de9d6b1"
-  integrity sha512-zyEC5hkguW2oieXRXp8VJzQdcO/1FxCS5GjzqOHItRlojXnx/cTavsrkxdWvBH9li2lUq0bN+LeeVEmyCwiR/Q==
+esbuild-windows-arm64@0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.8.tgz#512d06097cb4b848526a37c48a47223f1c6cc667"
+  integrity sha512-lTm5naoNgaUvzIiax3XYIEebqwr3bIIEEtqUhzQ2UQ+JMBmvhr02w3sJIJqF3axTX6TgWrC1OtM7DYNvFG+aXA==
+
+esbuild@^0.14.8:
+  version "0.14.8"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.8.tgz#f60a07ca9400d61d09a98f96d666c50613972550"
+  integrity sha512-stMsCBmxwaMpeK8GC/49L/cRGIwsHwoEN7Twk5zDTHlm/63c0KXFKzDC8iM2Mi3fyCKwS002TAH6IlAvqR6t3g==
   optionalDependencies:
-    esbuild-android-arm64 "0.14.3"
-    esbuild-darwin-64 "0.14.3"
-    esbuild-darwin-arm64 "0.14.3"
-    esbuild-freebsd-64 "0.14.3"
-    esbuild-freebsd-arm64 "0.14.3"
-    esbuild-linux-32 "0.14.3"
-    esbuild-linux-64 "0.14.3"
-    esbuild-linux-arm "0.14.3"
-    esbuild-linux-arm64 "0.14.3"
-    esbuild-linux-mips64le "0.14.3"
-    esbuild-linux-ppc64le "0.14.3"
-    esbuild-netbsd-64 "0.14.3"
-    esbuild-openbsd-64 "0.14.3"
-    esbuild-sunos-64 "0.14.3"
-    esbuild-windows-32 "0.14.3"
-    esbuild-windows-64 "0.14.3"
-    esbuild-windows-arm64 "0.14.3"
+    esbuild-android-arm64 "0.14.8"
+    esbuild-darwin-64 "0.14.8"
+    esbuild-darwin-arm64 "0.14.8"
+    esbuild-freebsd-64 "0.14.8"
+    esbuild-freebsd-arm64 "0.14.8"
+    esbuild-linux-32 "0.14.8"
+    esbuild-linux-64 "0.14.8"
+    esbuild-linux-arm "0.14.8"
+    esbuild-linux-arm64 "0.14.8"
+    esbuild-linux-mips64le "0.14.8"
+    esbuild-linux-ppc64le "0.14.8"
+    esbuild-linux-s390x "0.14.8"
+    esbuild-netbsd-64 "0.14.8"
+    esbuild-openbsd-64 "0.14.8"
+    esbuild-sunos-64 "0.14.8"
+    esbuild-windows-32 "0.14.8"
+    esbuild-windows-64 "0.14.8"
+    esbuild-windows-arm64 "0.14.8"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -2524,9 +2810,9 @@ eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.1.0:
   integrity sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==
 
 eslint@^8:
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.4.1.tgz#d6531bbf3e598dffd7c0c7d35ec52a0b30fdfa2d"
-  integrity sha512-TxU/p7LB1KxQ6+7aztTnO7K0i+h0tDi81YRY9VzB6Id71kNz+fFYnf5HD5UOQmxkzcoa0TlVZf9dpMtUv0GpWg==
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.5.0.tgz#ddd2c1afd8f412036f87ae2a063d2aa296d3175f"
+  integrity sha512-tVGSkgNbOfiHyVte8bCM8OmX+xG9PzVG/B4UCF60zx7j61WIVY/AqJECDgpLD4DbbESD0e174gOg3ZlrX15GDg==
   dependencies:
     "@eslint/eslintrc" "^1.0.5"
     "@humanwhocodes/config-array" "^0.9.2"
@@ -2767,9 +3053,9 @@ flat-cache@^3.0.4:
     rimraf "^3.0.2"
 
 flatted@^3.1.0:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.4.tgz#28d9969ea90661b5134259f312ab6aa7929ac5e2"
-  integrity sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
+  integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
 
 follow-redirects@^1.14.4:
   version "1.14.6"
@@ -3233,7 +3519,17 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.4, ignore@^5.1.8, ignore@^5.1.9:
+ignore@^5.1.4:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
+  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
+ignore@^5.1.8:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
+  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
+
+ignore@^5.1.9:
   version "5.1.9"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
   integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
@@ -3360,7 +3656,14 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
-is-core-module@^2.2.0, is-core-module@^2.5.0, is-core-module@^2.8.0:
+is-core-module@^2.2.0, is-core-module@^2.5.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.6.0.tgz#d7553b2526fe59b92ba3e40c8df757ec8a709e19"
+  integrity sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.0.tgz#0321336c3d0925e497fd97f5d95cb114a5ccd548"
   integrity sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==
@@ -3522,7 +3825,12 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
+istanbul-lib-coverage@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz#f5944a37c70b550b02a78a5c3b2055b280cec8ec"
+  integrity sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
+
+istanbul-lib-coverage@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz#189e7909d0a39fa5a3dfad5b03f71947770191d3"
   integrity sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==
@@ -3583,10 +3891,10 @@ jest-changed-files@^27.4.2:
     execa "^5.0.0"
     throat "^6.0.1"
 
-jest-circus@^27.4.4:
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.4.4.tgz#8bf89aa604b914ecc10e3d895aae283b529f965d"
-  integrity sha512-4DWhvQerDq5X4GaqhEUoZiBhuNdKDGr0geW0iJwarbDljAmGaGOErKQG+z2PBr0vgN05z7tsGSY51mdWr8E4xg==
+jest-circus@^27.4.5:
+  version "27.4.5"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.4.5.tgz#70bfb78e0200cab9b84747bf274debacaa538467"
+  integrity sha512-eTNWa9wsvBwPykhMMShheafbwyakcdHZaEYh5iRrQ0PFJxkDP/e3U/FvzGuKWu2WpwUA3C3hPlfpuzvOdTVqnw==
   dependencies:
     "@jest/environment" "^27.4.4"
     "@jest/test-result" "^27.4.2"
@@ -3600,54 +3908,54 @@ jest-circus@^27.4.4:
     jest-each "^27.4.2"
     jest-matcher-utils "^27.4.2"
     jest-message-util "^27.4.2"
-    jest-runtime "^27.4.4"
-    jest-snapshot "^27.4.4"
+    jest-runtime "^27.4.5"
+    jest-snapshot "^27.4.5"
     jest-util "^27.4.2"
     pretty-format "^27.4.2"
     slash "^3.0.0"
     stack-utils "^2.0.3"
     throat "^6.0.1"
 
-jest-cli@^27.4.4:
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.4.4.tgz#7115ff01f605c2c848314141b1ac144099ddeed5"
-  integrity sha512-+MfsHnZPUOBigCBURuQFRpgYoPCgmIFkICkqt4SrramZCUp/UAuWcst4pMZb84O3VU8JyKJmnpGG4qH8ClQloA==
+jest-cli@^27.4.5:
+  version "27.4.5"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.4.5.tgz#8708f54c28d13681f3255ec9026a2b15b03d41e8"
+  integrity sha512-hrky3DSgE0u7sQxaCL7bdebEPHx5QzYmrGuUjaPLmPE8jx5adtvGuOlRspvMoVLTTDOHRnZDoRLYJuA+VCI7Hg==
   dependencies:
-    "@jest/core" "^27.4.4"
+    "@jest/core" "^27.4.5"
     "@jest/test-result" "^27.4.2"
     "@jest/types" "^27.4.2"
     chalk "^4.0.0"
     exit "^0.1.2"
     graceful-fs "^4.2.4"
     import-local "^3.0.2"
-    jest-config "^27.4.4"
+    jest-config "^27.4.5"
     jest-util "^27.4.2"
     jest-validate "^27.4.2"
     prompts "^2.0.1"
     yargs "^16.2.0"
 
-jest-config@^27.4.4:
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-27.4.4.tgz#0e3615392361baae0e29dbf64c296d5563d7e28b"
-  integrity sha512-6lxg0ugO6KS2zKEbpdDwBzu1IT0Xg4/VhxXMuBu+z/5FvBjLCEMTaWQm3bCaGCZUR9j9FK4DzUIxyhIgn6kVEg==
+jest-config@^27.4.5:
+  version "27.4.5"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-27.4.5.tgz#77ed7f2ba7bcfd7d740ade711d0d13512e08a59e"
+  integrity sha512-t+STVJtPt+fpqQ8GBw850NtSQbnDOw/UzdPfzDaHQ48/AylQlW7LHj3dH+ndxhC1UxJ0Q3qkq7IH+nM1skwTwA==
   dependencies:
     "@babel/core" "^7.1.0"
-    "@jest/test-sequencer" "^27.4.4"
+    "@jest/test-sequencer" "^27.4.5"
     "@jest/types" "^27.4.2"
-    babel-jest "^27.4.4"
+    babel-jest "^27.4.5"
     chalk "^4.0.0"
     ci-info "^3.2.0"
     deepmerge "^4.2.2"
     glob "^7.1.1"
     graceful-fs "^4.2.4"
-    jest-circus "^27.4.4"
+    jest-circus "^27.4.5"
     jest-environment-jsdom "^27.4.4"
     jest-environment-node "^27.4.4"
     jest-get-type "^27.4.0"
-    jest-jasmine2 "^27.4.4"
+    jest-jasmine2 "^27.4.5"
     jest-regex-util "^27.4.0"
-    jest-resolve "^27.4.4"
-    jest-runner "^27.4.4"
+    jest-resolve "^27.4.5"
+    jest-runner "^27.4.5"
     jest-util "^27.4.2"
     jest-validate "^27.4.2"
     micromatch "^4.0.4"
@@ -3717,10 +4025,10 @@ jest-get-type@^27.4.0:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.4.0.tgz#7503d2663fffa431638337b3998d39c5e928e9b5"
   integrity sha512-tk9o+ld5TWq41DkK14L4wox4s2D9MtTpKaAVzXfr5CUKm5ZK2ExcaFE0qls2W71zE/6R2TxxrK9w2r6svAFDBQ==
 
-jest-haste-map@^27.4.4:
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.4.4.tgz#ec6013845368a155372e25e42e2b77e6ecc5019f"
-  integrity sha512-kvspmHmgPIZoDaqUsvsJFTaspuxhATvdO6wsFNGNSi8kfdiOCEEvECNbht8xG+eE5Ol88JyJmp2D7RF4dYo85Q==
+jest-haste-map@^27.4.5:
+  version "27.4.5"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.4.5.tgz#c2921224a59223f91e03ec15703905978ef0cc1a"
+  integrity sha512-oJm1b5qhhPs78K24EDGifWS0dELYxnoBiDhatT/FThgB9yxqUm5F6li3Pv+Q+apMBmmPNzOBnZ7ZxWMB1Leq1Q==
   dependencies:
     "@jest/types" "^27.4.2"
     "@types/graceful-fs" "^4.1.2"
@@ -3731,16 +4039,16 @@ jest-haste-map@^27.4.4:
     jest-regex-util "^27.4.0"
     jest-serializer "^27.4.0"
     jest-util "^27.4.2"
-    jest-worker "^27.4.4"
+    jest-worker "^27.4.5"
     micromatch "^4.0.4"
     walker "^1.0.7"
   optionalDependencies:
     fsevents "^2.3.2"
 
-jest-jasmine2@^27.4.4:
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.4.4.tgz#1fcdc64de932913366e7d5f2960c375e1145176e"
-  integrity sha512-ygk2tUgtLeN3ouj4KEYw9p81GLI1EKrnvourPULN5gdgB482PH5op9gqaRG0IenbJhBbbRwiSvh5NoBoQZSqdA==
+jest-jasmine2@^27.4.5:
+  version "27.4.5"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.4.5.tgz#ff79d11561679ff6c89715b0cd6b1e8c0dfbc6dc"
+  integrity sha512-oUnvwhJDj2LhOiUB1kdnJjkx8C5PwgUZQb9urF77mELH9DGR4e2GqpWQKBOYXWs5+uTN9BGDqRz3Aeg5Wts7aw==
   dependencies:
     "@babel/traverse" "^7.1.0"
     "@jest/environment" "^27.4.4"
@@ -3755,8 +4063,8 @@ jest-jasmine2@^27.4.4:
     jest-each "^27.4.2"
     jest-matcher-utils "^27.4.2"
     jest-message-util "^27.4.2"
-    jest-runtime "^27.4.4"
-    jest-snapshot "^27.4.4"
+    jest-runtime "^27.4.5"
+    jest-snapshot "^27.4.5"
     jest-util "^27.4.2"
     pretty-format "^27.4.2"
     throat "^6.0.1"
@@ -3822,24 +4130,24 @@ jest-regex-util@^27.4.0:
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-27.4.0.tgz#e4c45b52653128843d07ad94aec34393ea14fbca"
   integrity sha512-WeCpMpNnqJYMQoOjm1nTtsgbR4XHAk1u00qDoNBQoykM280+/TmgA5Qh5giC1ecy6a5d4hbSsHzpBtu5yvlbEg==
 
-jest-resolve-dependencies@^27.4.4:
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-27.4.4.tgz#dae11e067a6d6a9553f1386a0ea1efe5be0e2332"
-  integrity sha512-iAnpCXh81sd9nbyqySvm5/aV9X6JZKE0dQyFXTC8tptXcdrgS0vjPFy+mEgzPHxXw+tq4TQupuTa0n8OXwRIxw==
+jest-resolve-dependencies@^27.4.5:
+  version "27.4.5"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-27.4.5.tgz#9398af854bdb12d6a9e5a8a536ee401f889a3ecf"
+  integrity sha512-elEVvkvRK51y037NshtEkEnukMBWvlPzZHiL847OrIljJ8yIsujD2GXRPqDXC4rEVKbcdsy7W0FxoZb4WmEs7w==
   dependencies:
     "@jest/types" "^27.4.2"
     jest-regex-util "^27.4.0"
-    jest-snapshot "^27.4.4"
+    jest-snapshot "^27.4.5"
 
-jest-resolve@^27.4.4:
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.4.4.tgz#5b690662f54f38f7cfaffc0adcdb341ff7724408"
-  integrity sha512-Yh5jK3PBmDbm01Rc8pT0XqpBlTPEGwWp7cN61ijJuwony/tR2Taof3TLy6yfNiuRS8ucUOPO7NBYm3ei38kkcg==
+jest-resolve@^27.4.5:
+  version "27.4.5"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.4.5.tgz#8dc44f5065fb8d58944c20f932cb7b9fe9760cca"
+  integrity sha512-xU3z1BuOz/hUhVUL+918KqUgK+skqOuUsAi7A+iwoUldK6/+PW+utK8l8cxIWT9AW7IAhGNXjSAh1UYmjULZZw==
   dependencies:
     "@jest/types" "^27.4.2"
     chalk "^4.0.0"
     graceful-fs "^4.2.4"
-    jest-haste-map "^27.4.4"
+    jest-haste-map "^27.4.5"
     jest-pnp-resolver "^1.2.2"
     jest-util "^27.4.2"
     jest-validate "^27.4.2"
@@ -3847,15 +4155,15 @@ jest-resolve@^27.4.4:
     resolve.exports "^1.1.0"
     slash "^3.0.0"
 
-jest-runner@^27.4.4:
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-27.4.4.tgz#0b40cdcbac293ebc4c19c2d7805d17ab1072f1fd"
-  integrity sha512-AXv/8Q0Xf1puWnDf52m7oLrK7sXcv6re0V/kItwTSVHJbX7Oebm07oGFQqGmq0R0mhO1zpmB3OpqRuaCN2elPA==
+jest-runner@^27.4.5:
+  version "27.4.5"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-27.4.5.tgz#daba2ba71c8f34137dc7ac45616add35370a681e"
+  integrity sha512-/irauncTfmY1WkTaRQGRWcyQLzK1g98GYG/8QvIPviHgO1Fqz1JYeEIsSfF+9mc/UTA6S+IIHFgKyvUrtiBIZg==
   dependencies:
     "@jest/console" "^27.4.2"
     "@jest/environment" "^27.4.4"
     "@jest/test-result" "^27.4.2"
-    "@jest/transform" "^27.4.4"
+    "@jest/transform" "^27.4.5"
     "@jest/types" "^27.4.2"
     "@types/node" "*"
     chalk "^4.0.0"
@@ -3865,27 +4173,27 @@ jest-runner@^27.4.4:
     jest-docblock "^27.4.0"
     jest-environment-jsdom "^27.4.4"
     jest-environment-node "^27.4.4"
-    jest-haste-map "^27.4.4"
+    jest-haste-map "^27.4.5"
     jest-leak-detector "^27.4.2"
     jest-message-util "^27.4.2"
-    jest-resolve "^27.4.4"
-    jest-runtime "^27.4.4"
+    jest-resolve "^27.4.5"
+    jest-runtime "^27.4.5"
     jest-util "^27.4.2"
-    jest-worker "^27.4.4"
+    jest-worker "^27.4.5"
     source-map-support "^0.5.6"
     throat "^6.0.1"
 
-jest-runtime@^27.4.4:
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.4.4.tgz#0d486735e8a1c8bbcdbb9285b3155ed94c5e3670"
-  integrity sha512-tZGay6P6vXJq8t4jVFAUzYHx+lzIHXjz+rj1XBk6mAR1Lwtf5kz0Uun7qNuU+oqpZu4+hhuxpUfXb6j30bEPqA==
+jest-runtime@^27.4.5:
+  version "27.4.5"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.4.5.tgz#97703ad2a1799d4f50ab59049bd21a9ceaed2813"
+  integrity sha512-CIYqwuJQXHQtPd/idgrx4zgJ6iCb6uBjQq1RSAGQrw2S8XifDmoM1Ot8NRd80ooAm+ZNdHVwsktIMGlA1F1FAQ==
   dependencies:
     "@jest/console" "^27.4.2"
     "@jest/environment" "^27.4.4"
     "@jest/globals" "^27.4.4"
     "@jest/source-map" "^27.4.0"
     "@jest/test-result" "^27.4.2"
-    "@jest/transform" "^27.4.4"
+    "@jest/transform" "^27.4.5"
     "@jest/types" "^27.4.2"
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
@@ -3895,12 +4203,12 @@ jest-runtime@^27.4.4:
     exit "^0.1.2"
     glob "^7.1.3"
     graceful-fs "^4.2.4"
-    jest-haste-map "^27.4.4"
+    jest-haste-map "^27.4.5"
     jest-message-util "^27.4.2"
     jest-mock "^27.4.2"
     jest-regex-util "^27.4.0"
-    jest-resolve "^27.4.4"
-    jest-snapshot "^27.4.4"
+    jest-resolve "^27.4.5"
+    jest-snapshot "^27.4.5"
     jest-util "^27.4.2"
     jest-validate "^27.4.2"
     slash "^3.0.0"
@@ -3915,10 +4223,10 @@ jest-serializer@^27.4.0:
     "@types/node" "*"
     graceful-fs "^4.2.4"
 
-jest-snapshot@^27.4.4:
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.4.4.tgz#fc0a2cd22f742fe66621c5359c9cd64f88260c6b"
-  integrity sha512-yy+rpCvYMOjTl7IMuaMI9OP9WT229zi8BhdNHm6e6mttAOIzvIiCxFoZ6yRxaV3HDPPgMryi+ReX2b8+IQJdPA==
+jest-snapshot@^27.4.5:
+  version "27.4.5"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.4.5.tgz#2ea909b20aac0fe62504bc161331f730b8a7ecc7"
+  integrity sha512-eCi/iM1YJFrJWiT9de4+RpWWWBqsHiYxFG9V9o/n0WXs6GpW4lUt4FAHAgFPTLPqCUVzrMQmSmTZSgQzwqR7IQ==
   dependencies:
     "@babel/core" "^7.7.2"
     "@babel/generator" "^7.7.2"
@@ -3926,7 +4234,7 @@ jest-snapshot@^27.4.4:
     "@babel/plugin-syntax-typescript" "^7.7.2"
     "@babel/traverse" "^7.7.2"
     "@babel/types" "^7.0.0"
-    "@jest/transform" "^27.4.4"
+    "@jest/transform" "^27.4.5"
     "@jest/types" "^27.4.2"
     "@types/babel__traverse" "^7.0.4"
     "@types/prettier" "^2.1.5"
@@ -3936,10 +4244,10 @@ jest-snapshot@^27.4.4:
     graceful-fs "^4.2.4"
     jest-diff "^27.4.2"
     jest-get-type "^27.4.0"
-    jest-haste-map "^27.4.4"
+    jest-haste-map "^27.4.5"
     jest-matcher-utils "^27.4.2"
     jest-message-util "^27.4.2"
-    jest-resolve "^27.4.4"
+    jest-resolve "^27.4.5"
     jest-util "^27.4.2"
     natural-compare "^1.4.0"
     pretty-format "^27.4.2"
@@ -3982,23 +4290,23 @@ jest-watcher@^27.4.2:
     jest-util "^27.4.2"
     string-length "^4.0.1"
 
-jest-worker@^27.4.4:
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.4.4.tgz#9390a97c013a54d07f5c2ad2b5f6109f30c4966d"
-  integrity sha512-jfwxYJvfua1b1XkyuyPh01ATmgg4e5fPM/muLmhy9Qc6dmiwacQB0MLHaU6IjEsv/+nAixHGxTn8WllA27Pn0w==
+jest-worker@^27.4.5:
+  version "27.4.5"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.4.5.tgz#d696e3e46ae0f24cff3fa7195ffba22889262242"
+  integrity sha512-f2s8kEdy15cv9r7q4KkzGXvlY0JTcmCbMHZBfSQDwW77REr45IDWwd0lksDFeVHH2jJ5pqb90T77XscrjeGzzg==
   dependencies:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^27.4.4:
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-27.4.4.tgz#9b1aa1db25d0b13477a49d18e22ba7cdff97105b"
-  integrity sha512-AXwEIFa58Uf1Jno3/KSo5HZZ0/2Xwqvfrz0/3bmTwImkFlbOvz5vARAW9nTrxRLkojjkitaZ1KNKAtw3JRFAaA==
+jest@^27.4.5:
+  version "27.4.5"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-27.4.5.tgz#66e45acba44137fac26be9d3cc5bb031e136dc0f"
+  integrity sha512-uT5MiVN3Jppt314kidCk47MYIRilJjA/l2mxwiuzzxGUeJIvA8/pDaJOAX5KWvjAo7SCydcW0/4WEtgbLMiJkg==
   dependencies:
-    "@jest/core" "^27.4.4"
+    "@jest/core" "^27.4.5"
     import-local "^3.0.2"
-    jest-cli "^27.4.4"
+    jest-cli "^27.4.5"
 
 jju@^1.1.0:
   version "1.4.0"
@@ -4401,7 +4709,7 @@ make-fetch-happen@^9.0.1, make-fetch-happen@^9.1.0:
     socks-proxy-agent "^6.0.0"
     ssri "^8.0.0"
 
-makeerror@1.0.12:
+makeerror@1.0.x:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.12.tgz#3e5dd2079a82e812e983cc6610c4a2cb0eaa801a"
   integrity sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==
@@ -4462,17 +4770,17 @@ micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
-mime-db@1.51.0:
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
-  integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
+mime-db@1.49.0:
+  version "1.49.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.49.0.tgz#f3dfde60c99e9cf3bc9701d687778f537001cbed"
+  integrity sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==
 
 mime-types@^2.1.12:
-  version "2.1.34"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
-  integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
+  version "2.1.32"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.32.tgz#1d00e89e7de7fe02008db61001d9e02852670fd5"
+  integrity sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==
   dependencies:
-    mime-db "1.51.0"
+    mime-db "1.49.0"
 
 mime@^2.6.0:
   version "2.6.0"
@@ -4599,21 +4907,6 @@ moment-timezone@^0.5.31:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
-monocdk@^1.135.0:
-  version "1.135.0"
-  resolved "https://registry.yarnpkg.com/monocdk/-/monocdk-1.135.0.tgz#910bdbed9f732f6ebf4ee5ca740d013d80b7e56d"
-  integrity sha512-TsCTyfIQbnW6m+W5yPpBM4CugEjOzjUDvTD99BgQn6J17LCeaXZJoBUp4KmfE2C3ZEUBndysazoBw4DPj2RbXg==
-  dependencies:
-    "@balena/dockerignore" "^1.0.2"
-    case "1.6.3"
-    fs-extra "^9.1.0"
-    ignore "^5.1.9"
-    jsonschema "^1.4.0"
-    minimatch "^3.0.4"
-    punycode "^2.1.1"
-    semver "^7.3.5"
-    yaml "1.10.2"
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -4735,9 +5028,9 @@ npm-bundled@^1.1.1:
     npm-normalize-package-bin "^1.0.1"
 
 npm-check-updates@^12:
-  version "12.0.3"
-  resolved "https://registry.yarnpkg.com/npm-check-updates/-/npm-check-updates-12.0.3.tgz#860f8c20e4d05780929a0daa8ac52e006b878440"
-  integrity sha512-MTHzkDZY1ebhPaDvzWOU9bt4UYdHmY4tIcMCaZjgguGKUgwqokH/aB0Nrc4WcZ4rD491Spuj5DILo/RvKAefvw==
+  version "12.0.5"
+  resolved "https://registry.yarnpkg.com/npm-check-updates/-/npm-check-updates-12.0.5.tgz#bd5606b4a645e5edfc31cc7a1c93e60dd3e14b9a"
+  integrity sha512-ns1liBBogwjmOVZY/PYgeIoarItwdOSBxccJDZKKkxsMkXges/Bp5CAnQIvYwlsz6fByQJFvqXSOqwIUBY6gpQ==
   dependencies:
     chalk "^4.1.2"
     cint "^8.2.1"
@@ -5196,10 +5489,10 @@ progress@^2.0.0, progress@^2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-projen@^0.40.9:
-  version "0.40.9"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.40.9.tgz#d525c45429743f26f2a916d67506486d87112373"
-  integrity sha512-akf+pixL+d9xmu8hXWO4O2N0I4u0q0MmtMoYSPDd6QYz4ox46ZOtwpNbLi13bSmVfxLUTYZleacu6UrfvTST2w==
+projen@^0.46.3:
+  version "0.46.3"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.46.3.tgz#ccd7ab21cd57c2409bf9cad116aaec689daaa55e"
+  integrity sha512-Zo5emBAy9IAfz6EXlZqjLt5doYBQ71M350jCh2GkUbHCMgRnd7Vu/merWaWp75L1Zrba9yi6GZq8eoGh3jpt7A==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"
@@ -5234,7 +5527,15 @@ promptly@^3.2.0:
   dependencies:
     read "^1.0.4"
 
-prompts@^2.0.1, prompts@^2.4.2:
+prompts@^2.0.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.1.tgz#befd3b1195ba052f9fd2fde8a486c4e82ee77f61"
+  integrity sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==
+  dependencies:
+    kleur "^3.0.3"
+    sisteransi "^1.0.5"
+
+prompts@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
   integrity sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==
@@ -5740,10 +6041,18 @@ socks@^2.3.3, socks@^2.6.1:
     ip "^1.1.5"
     smart-buffer "^4.1.0"
 
-source-map-support@^0.5.21, source-map-support@^0.5.6:
+source-map-support@^0.5.21:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@^0.5.6:
+  version "0.5.20"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.20.tgz#12166089f8f5e5e8c56926b377633392dd2cb6c9"
+  integrity sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -5790,9 +6099,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz#50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95"
-  integrity sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz#0d9becccde7003d6c658d487dd48a32f0bf3014b"
+  integrity sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==
 
 split2@^3.0.0:
   version "3.2.2"
@@ -5861,7 +6170,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5869,6 +6178,15 @@ string-length@^4.0.1:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
+
+string-width@^4.0.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
+  integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
 
 string.prototype.trimend@^1.0.4:
   version "1.0.4"
@@ -6117,10 +6435,10 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
-ts-jest@^27.1.1:
-  version "27.1.1"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.1.tgz#5a54aca96db1dac37c681f3029dd10f3a8c36192"
-  integrity sha512-Ds0VkB+cB+8g2JUmP/GKWndeZcCKrbe6jzolGrVWdqVUFByY/2KDHqxJ7yBSon7hDB1TA4PXxjfZ+JjzJisvgA==
+ts-jest@^27.1.2:
+  version "27.1.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.2.tgz#5991d6eb3fd8e1a8d4b8f6de3ec0a3cc567f3151"
+  integrity sha512-eSOiJOWq6Hhs6Khzk5wKC5sgWIXgXqOCiIl1+3lfnearu58Hj4QpE5tUhQcA3xtZrELbcvAGCsd6HB8OsaVaTA==
   dependencies:
     bs-logger "0.x"
     fast-json-stable-stringify "2.x"
@@ -6214,10 +6532,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@~4.5.3:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.3.tgz#afaa858e68c7103317d89eb90c5d8906268d353c"
-  integrity sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==
+typescript@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
+  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
 
 uglify-js@^3.1.4:
   version "3.14.5"
@@ -6376,11 +6694,11 @@ w3c-xmlserializer@^2.0.0:
     xml-name-validator "^3.0.0"
 
 walker@^1.0.7:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"
-  integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
+  integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
-    makeerror "1.0.12"
+    makeerror "1.0.x"
 
 webidl-conversions@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This PR upgrades delivlib to use CDK v2. It also migrates the tests to
use the `assertions` library.

BREAKING CHANGE: delivlib now requires cdk v2

re https://github.com/cdklabs/cdk-ops/issues/1841


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.