### PR TITLE
fix(integ test): updates the hash of the lambda function

### DIFF
--- a/lib/__tests__/expected.yml
+++ b/lib/__tests__/expected.yml
@@ -4350,7 +4350,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: cdk-hnb659fds-assets-712950704752-us-east-1
-        S3Key: 6d84cdad0db1b0ef3c0db08c3e9ceb1ca56b3f8ffc4e1e1fd23f9a51b052e8fd.zip
+        S3Key: 61b19c56a416da0f30cc3827cdab3398860dbddd41acf08b9c240ebbdf1605ed.zip
       Role:
         Fn::GetAtt:
           - CodeCommitPipelineChangeControllerFunctionServiceRoleF02841DB


### PR DESCRIPTION
A dependency upgrade changed this lambda hash, which is updated by this PR.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.