### PR TITLE
fix: ECR mirrorring uses incorrect jsii/superchain tag

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -59,7 +59,7 @@
       "description": "Bundle the package integrity script",
       "steps": [
         {
-          "exec": "esbuild --bundle lib/package-integrity/handler/validate.js --target=\"node12\" --platform=\"node\" --outfile=\"lib/package-integrity/handler/validate.bundle.js\" --sourcemap=inline"
+          "exec": "esbuild --bundle lib/package-integrity/handler/validate.js --target=\"node14\" --platform=\"node\" --outfile=\"lib/package-integrity/handler/validate.bundle.js\" --sourcemap=inline"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -99,7 +99,7 @@ const bundlePackageIntegrity = project.addTask('bundle:package-integrity', {
     'esbuild',
     '--bundle',
     'lib/package-integrity/handler/validate.js',
-    '--target="node12"',
+    '--target="node14"',
     '--platform="node"',
     '--outfile="lib/package-integrity/handler/validate.bundle.js"',
     '--sourcemap=inline',

--- a/README.md
+++ b/README.md
@@ -794,7 +794,7 @@ a local ECR registry in the AWS account.
 ```ts
 new EcrMirror(this, 'RegistrySync', {
   sources: [
-    MirrorSource.fromDockerHub('jsii/superchain'),
+    MirrorSource.fromDockerHub('jsii/superchain:1-buster-slim'),
     MirrorSource.fromDockerHub('python:3.6'),
   ],
   dockerhubCredentials: // ...

--- a/lib/__tests__/expected.yml
+++ b/lib/__tests__/expected.yml
@@ -1151,7 +1151,7 @@ Resources:
           METRIC_NAMESPACE: CDK/Delivlib
           METRIC_NAME: Failures
       Handler: watcher-handler.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
     DependsOn:
       - CodeCommitPipelinePipelineWatcherPollerServiceRoleDefaultPolicyE2104AD1
       - CodeCommitPipelinePipelineWatcherPollerServiceRole0A1D8005
@@ -2612,7 +2612,7 @@ Resources:
             Type: PLAINTEXT
             Value:
               Ref: X509CodeSigningKey8DE65BF8
-        Image: jsii/superchain
+        Image: jsii/superchain:1-buster-slim
         ImagePullCredentialsType: SERVICE_ROLE
         PrivilegedMode: false
         Type: LINUX_CONTAINER
@@ -2827,7 +2827,7 @@ Resources:
           - Name: MAVEN_ENDPOINT
             Type: PLAINTEXT
             Value: https://aws.oss.sonatype.org:443/
-        Image: jsii/superchain
+        Image: jsii/superchain:1-buster-slim
         ImagePullCredentialsType: SERVICE_ROLE
         PrivilegedMode: false
         Type: LINUX_CONTAINER
@@ -3030,7 +3030,7 @@ Resources:
             Value: cdk-hnb659fds-assets-712950704752-us-east-1
           - Name: SCRIPT_S3_KEY
             Type: PLAINTEXT
-            Value: 913f58db1d9c6ec6c47a25df05cd634bb9ac31aae25b7fb761bb66400ec31bb6.zip
+            Value: 9230bf0a9059a035ed9bcde31fc47407831e89734f5c4b4e9c47c2ea45799941.zip
           - Name: BUILD_MANIFEST
             Type: PLAINTEXT
             Value: ./build.json
@@ -4083,7 +4083,7 @@ Resources:
           STAGE_NAME: Publish
           AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1"
       Handler: index.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       Timeout: 300
     DependsOn:
       - CodeCommitPipelineChangeControllerFunctionServiceRoleDefaultPolicy315F7AF5
@@ -4374,7 +4374,7 @@ Resources:
       Handler: index.handler
       Layers:
         - Ref: X509CodeSigningKeyRSAPrivateKeyOpenSslCliLayer3F0C7B04
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       Timeout: 300
     DependsOn:
       - RSAPrivateKey72FD327D38134632934028EC437AA486ServiceRoleDefaultPolicy487DB1EA
@@ -4452,7 +4452,7 @@ Resources:
       Handler: index.handler
       Layers:
         - Ref: X509CodeSigningKeyRSAPrivateKeyCertificateSigningRequestOpenSslCliLayer61AF8E77
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       Timeout: 300
     DependsOn:
       - CreateCSR541F67826DCF49A78C5A67715ADD9E4CServiceRoleDefaultPolicyC0800208
@@ -4653,7 +4653,7 @@ Resources:
       Handler: index.handler
       Layers:
         - Ref: CodeSignGpgLayer4D38F47B
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       Timeout: 300
     DependsOn:
       - SingletonLambdaf25803d3054b44fc985f4860d7d6ee74ServiceRoleDefaultPolicyA8FDF5BD

--- a/lib/__tests__/expected.yml
+++ b/lib/__tests__/expected.yml
@@ -3030,7 +3030,7 @@ Resources:
             Value: cdk-hnb659fds-assets-712950704752-us-east-1
           - Name: SCRIPT_S3_KEY
             Type: PLAINTEXT
-            Value: 9230bf0a9059a035ed9bcde31fc47407831e89734f5c4b4e9c47c2ea45799941.zip
+            Value: 913f58db1d9c6ec6c47a25df05cd634bb9ac31aae25b7fb761bb66400ec31bb6.zip
           - Name: BUILD_MANIFEST
             Type: PLAINTEXT
             Value: ./build.json

--- a/lib/__tests__/package-integrity/integrity.test.ts
+++ b/lib/__tests__/package-integrity/integrity.test.ts
@@ -12,7 +12,7 @@ test('creates a codebuild project that triggers daily and runs the integrity han
   const token = sm.Secret.fromSecretCompleteArn(stack, 'GitHubSecret', 'arn:aws:secretsmanager:us-east-1:123456789123:secret:github-token-000000');
 
   new PackageIntegrityValidation(stack, 'Integrity', {
-    buildPlatform: new LinuxPlatform(codebuild.LinuxBuildImage.fromDockerRegistry('jsii/superchain:1-buster-slim-node12')),
+    buildPlatform: new LinuxPlatform(codebuild.LinuxBuildImage.fromDockerRegistry('jsii/superchain:1-buster-slim-node14')),
     githubTokenSecret: token,
     repository: 'cdklabs/some-repo',
   });

--- a/lib/__tests__/registry-sync/ecr-mirror.test.ts
+++ b/lib/__tests__/registry-sync/ecr-mirror.test.ts
@@ -36,7 +36,7 @@ describe('EcrMirror', () => {
             Value: '123aass:password-key:AWSCURRENT',
           },
         ],
-        Image: 'jsii/superchain',
+        Image: 'jsii/superchain:1-buster-slim',
         RegistryCredential: {
           Credential: '123aass',
           CredentialProvider: 'SECRETS_MANAGER',

--- a/lib/change-controller.ts
+++ b/lib/change-controller.ts
@@ -79,7 +79,7 @@ export class ChangeController extends Construct {
     const fn = new nodejs.NodejsFunction(this, 'Function', {
       description: `Enforces a Change Control Policy into CodePipeline's ${props.pipelineStage.stageName} stage`,
       entry: path.join(__dirname, 'change-control-lambda', 'index.ts'),
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       environment: {
         // CAPITAL punishment 👌🏻
         CHANGE_CONTROL_BUCKET_NAME: changeControlBucket.bucketName,

--- a/lib/chime-notifier/chime-notifier.ts
+++ b/lib/chime-notifier/chime-notifier.ts
@@ -56,7 +56,7 @@ export class ChimeNotifier extends Construct {
         handler: 'index.handler',
         uuid: '0f4a3ee0-692e-4249-932f-a46a833886d8',
         code: lambda.Code.fromAsset(path.join(__dirname, 'handler')),
-        runtime: lambda.Runtime.NODEJS_12_X,
+        runtime: lambda.Runtime.NODEJS_14_X,
         timeout: Duration.minutes(5),
       });
 

--- a/lib/code-signing/certificate-signing-request.ts
+++ b/lib/code-signing/certificate-signing-request.ts
@@ -61,7 +61,7 @@ export class CertificateSigningRequest extends Construct {
       uuid: '541F6782-6DCF-49A7-8C5A-67715ADD9E4C',
       lambdaPurpose: 'CreateCSR',
       description: 'Creates a Certificate Signing Request document for an x509 certificate',
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       handler: 'index.handler',
       code: new lambda.AssetCode(codeLocation),
       timeout: Duration.seconds(300),

--- a/lib/code-signing/private-key.ts
+++ b/lib/code-signing/private-key.ts
@@ -67,7 +67,7 @@ export class RsaPrivateKeySecret extends Construct {
       lambdaPurpose: 'RSAPrivate-Key',
       uuid: '72FD327D-3813-4632-9340-28EC437AA486',
       description: 'Generates an RSA Private Key and stores it in AWS Secrets Manager',
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       handler: 'index.handler',
       code: new lambda.AssetCode(codeLocation),
       timeout: Duration.seconds(300),

--- a/lib/open-pgp-key-pair.ts
+++ b/lib/open-pgp-key-pair.ts
@@ -120,7 +120,7 @@ export class OpenPGPKeyPair extends Construct implements ICredentialPair {
       code: new lambda.AssetCode(codeLocation),
       handler: 'index.handler',
       timeout: Duration.seconds(300),
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       // add the layer that contains the GPG binary (+ shared libraries)
       layers: [new lambda.LayerVersion(this, 'GpgLayer', {
         code: lambda.Code.fromAsset(path.join(__dirname, 'custom-resource-handlers', 'layers', 'gpg-layer.zip')),

--- a/lib/pipeline-watcher/watcher.ts
+++ b/lib/pipeline-watcher/watcher.ts
@@ -53,7 +53,7 @@ export class PipelineWatcher extends Construct {
 
     const pipelineWatcher = new lambda.Function(this, 'Poller', {
       handler: 'watcher-handler.handler',
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       code: lambda.Code.fromAsset(path.join(__dirname, 'handler')),
       environment: {
         METRIC_NAMESPACE: props.metricNamespace,

--- a/lib/publishing.ts
+++ b/lib/publishing.ts
@@ -83,7 +83,7 @@ export class PublishToMavenProject extends Construct implements IPublisher {
     const forReal = props.dryRun === undefined ? 'false' : (!props.dryRun).toString();
 
     const shellable = new Shellable(this, 'Default', {
-      platform: new LinuxPlatform(props.buildImage ?? cbuild.LinuxBuildImage.fromDockerRegistry('jsii/superchain')),
+      platform: new LinuxPlatform(props.buildImage ?? cbuild.LinuxBuildImage.fromDockerRegistry('jsii/superchain:1-buster-slim')),
       scriptDirectory: path.join(__dirname, 'publishing', 'maven'),
       entrypoint: 'publish.sh',
       environment: {
@@ -251,7 +251,7 @@ export class PublishToNuGetProject extends Construct implements IPublisher {
     }
 
     const shellable = new Shellable(this, 'Default', {
-      platform: new LinuxPlatform(props.buildImage ?? cbuild.LinuxBuildImage.fromDockerRegistry('jsii/superchain')),
+      platform: new LinuxPlatform(props.buildImage ?? cbuild.LinuxBuildImage.fromDockerRegistry('jsii/superchain:1-buster-slim')),
       scriptDirectory: path.join(__dirname, 'publishing', 'nuget'),
       entrypoint: 'publish.sh',
       environment,

--- a/lib/registry-sync/ecr-mirror.ts
+++ b/lib/registry-sync/ecr-mirror.ts
@@ -102,7 +102,7 @@ export class EcrMirror extends Construct {
     this._project = new codebuild.Project(this, 'EcrPushImages', {
       environment: {
         privileged: true,
-        buildImage: codebuild.LinuxBuildImage.fromDockerRegistry('jsii/superchain', {
+        buildImage: codebuild.LinuxBuildImage.fromDockerRegistry('jsii/superchain:1-buster-slim', {
           secretsManagerCredentials: props.dockerHubCredentials.secret,
         }),
       },


### PR DESCRIPTION
The default (`latest`) tag was being used, but it no longer exists.
Replaces it with the `1-buster-slim` tag which is the recommended
substitute.

Also, upgrades to Node 14.x where Node 12.x was still being used.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.