### PR TITLE
chore(deps): upgrade projen

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -93,17 +93,16 @@
       "type": "build"
     },
     {
+      "name": "jest",
+      "type": "build"
+    },
+    {
       "name": "jest-create-mock-instance",
       "type": "build"
     },
     {
       "name": "jest-junit",
       "version": "^13",
-      "type": "build"
-    },
-    {
-      "name": "jest",
-      "version": "^27",
       "type": "build"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -296,7 +296,7 @@
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @types/adm-zip @types/aws-lambda @types/follow-redirects @types/fs-extra @types/jest @types/node @types/tar @typescript-eslint/eslint-plugin @typescript-eslint/parser adm-zip aws-cdk aws-sdk aws-sdk-mock esbuild eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint follow-redirects fs-extra jest-create-mock-instance jest-junit jest json-schema JSONStream node-ical npm-check-updates projen rrule standard-version tar ts-jest typescript changelog-parser"
+          "exec": "yarn upgrade @types/adm-zip @types/aws-lambda @types/follow-redirects @types/fs-extra @types/jest @types/node @types/tar @typescript-eslint/eslint-plugin @typescript-eslint/parser adm-zip aws-cdk aws-sdk aws-sdk-mock esbuild eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint follow-redirects fs-extra jest jest-create-mock-instance jest-junit json-schema JSONStream node-ical npm-check-updates projen rrule standard-version tar ts-jest typescript changelog-parser"
         },
         {
           "exec": "npx projen"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "JSONStream": "^1.3.5",
     "node-ical": "^0.15.1",
     "npm-check-updates": "^12",
-    "projen": "^0.57.9",
+    "projen": "^0.58.27",
     "rrule": "^2.7.0",
     "standard-version": "^9",
     "tar": "^6.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5003,10 +5003,10 @@ progress@^2.0.3:
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-projen@^0.57.9:
-  version "0.57.9"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.57.9.tgz#a75a131f3240611becd11221e8540b9e7a8069f4"
-  integrity sha512-DO2m8xUtWQS7R/aPbyqStzHxVJv3aMgXwkq3FvPzdPBe08mthNe73qgZfF+y4Y7E8pPhvl/UvvG1YkKsxfYBQw==
+projen@^0.58.27:
+  version "0.58.27"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.58.27.tgz#dd35daa2edfe6e099e0d45470d175fda011fcf3a"
+  integrity sha512-xNeWZ5tBH+bz50Dz4rznwfyqnrbC1pguX2VdjpaU6+RVX3ooTgdSSKItJgPx3Dx2S8sQcRfZpEVDbRjpAkMCgw==
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"


### PR DESCRIPTION
Manually bump projen because the automatic dependency upgrades [PR](https://github.com/cdklabs/aws-delivlib/pull/1134) has been failing for a while (we are on it).

This is needed because the new version of projen contains a [fix](https://github.com/projen/projen/pull/1947) to jest issue currently failing our unit tests.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.