### PR TITLE
fix: upgrade nodejs-lts in Windows Shellables

### DIFF
--- a/lib/build-spec.ts
+++ b/lib/build-spec.ts
@@ -48,6 +48,7 @@ export class BuildSpec {
     return new BuildSpec({
       version: '0.2',
       phases: noUndefined({
+        install: props.install !== undefined ? { commands: props.install } : undefined,
         pre_build: props.preBuild !== undefined ? { commands: props.preBuild } : undefined,
         build: props.build !== undefined ? { commands: props.build } : undefined,
       }),
@@ -162,6 +163,7 @@ export class BuildSpec {
 }
 
 export interface SimpleBuildSpecProps {
+  install?: string[];
   preBuild?: string[];
   build?: string[];
   reports?: {[key: string]: ReportStruct};

--- a/lib/shellable.ts
+++ b/lib/shellable.ts
@@ -265,6 +265,7 @@ export class Shellable extends Construct {
     }
 
     this.buildSpec = BuildSpec.simple({
+      install: this.platform.installCommands(),
       preBuild: this.platform.prebuildCommands(props.assumeRole, props.useRegionalStsEndpoints),
       build: this.platform.buildCommands(props.entrypoint),
     }).merge(props.buildSpec || BuildSpec.empty());
@@ -387,6 +388,11 @@ export abstract class ShellPlatform {
   }
 
   /**
+   * Retrn commands to prepare the host for the shellable.
+   */
+  public abstract installCommands(): string[] | undefined;
+
+  /**
    * Return commands to download the script bundle
    */
   public abstract prebuildCommands(assumeRole?: AssumeRole, useRegionalStsEndpoints?: boolean): string[];
@@ -407,6 +413,10 @@ export abstract class ShellPlatform {
  */
 export class LinuxPlatform extends ShellPlatform {
   public readonly platformType = PlatformType.Linux;
+
+  public installCommands(): string[] | undefined {
+    return undefined;
+  }
 
   public prebuildCommands(assumeRole?: AssumeRole, useRegionalStsEndpoints?: boolean): string[] {
     const lines = new Array<string>();
@@ -475,6 +485,14 @@ export class LinuxPlatform extends ShellPlatform {
  */
 export class WindowsPlatform extends ShellPlatform {
   public readonly platformType = PlatformType.Windows;
+
+  public installCommands(): string[] | undefined {
+    return [
+      // Update the image's nodejs to the latest LTS release.
+      'Import-Module "C:\\ProgramData\\chocolatey\\helpers\\chocolateyProfile.psm1"',
+      'C:\\ProgramData\\chocolatey\\bin\\choco.exe upgrade nodejs-lts -y',
+    ];
+  }
 
   public prebuildCommands(assumeRole?: AssumeRole, _useRegionalStsEndpoints?: boolean): string[] {
     if (assumeRole) {


### PR DESCRIPTION
The nodejs version that ships in the standard Windows CodeBuild image is relatively old (October 2020), so we upgrade the `nodejs-lts` package in the `install` phase to get something more recent.

This is necessary in order for `jsii@5.0.x` to be install-able & usable, due to the reliance on the `node:` pseudo-protocol.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.