### PR TITLE
chore: authenticate ECRMirror to ECR Public

### DIFF
--- a/lib/__tests__/change-control-lambda/time-window.test.ts
+++ b/lib/__tests__/change-control-lambda/time-window.test.ts
@@ -79,27 +79,32 @@ END:VEVENT
 END:VCALENDAR
 `;
 
-test('non blocked time before all events', () => {
+// The tests below can only run if TZ=UTC due to an issue in `node-ical`.
+const test_ = new Date().getTimezoneOffset() !== 0
+  ? test.skip
+  : test;
+
+test_('non blocked time before all events', () => {
   const x = shouldBlockPipeline(ics, new Date('2019-02-03T07:00:00.000Z'), 300);
   expect(x).toBeUndefined();
 });
 
-test('non blocked time in between events', () => {
+test_('non blocked time in between events', () => {
   const x = shouldBlockPipeline(ics, new Date('2017-07-12T07:00:00.000Z'));
   expect(x).toBeUndefined();
 });
 
-test('left edge', () => {
+test_('left edge', () => {
   const x = shouldBlockPipeline(ics, new Date('2017-04-12T07:00:00.000Z'));
   expect(x && x.summary).toBe('Block1');
 });
 
-test('right edge', () => {
+test_('right edge', () => {
   const x = shouldBlockPipeline(ics, new Date('2017-11-27T08:00:00.000Z'));
   expect(x && x.summary).toBe('Block2');
 });
 
-test('a blocked window starts AND finishes within margin', () => {
+test_('a blocked window starts AND finishes within margin', () => {
   // Using 72 hours padding to widely overlap Block3
   const x = shouldBlockPipeline(ics, new Date('2019-02-03T07:00:00.000Z'), 72 * 3_600);
   expect(x && x.summary).toBe('Block3');
@@ -107,21 +112,21 @@ test('a blocked window starts AND finishes within margin', () => {
 
 // Test that the initial event in a recurring series blocks the pipeline when
 // the left edge aligns with the current time.
-test('current time aligns with the left edge of the first event in a series blocks pipeline', () => {
+test_('current time aligns with the left edge of the first event in a series blocks pipeline', () => {
   const x = shouldBlockPipeline(recurringIcs, new Date('2020-05-01T22:00:00.000Z'));
   expect(x && x.summary).toBe('RecurringBlock1');
 });
 
 // Test that a future event in a recurring series blocks the pipeline when
 // the left edge aligns with the current time.
-test('current time aligns with the left edge of future event in a series blocks pipeline', () => {
+test_('current time aligns with the left edge of future event in a series blocks pipeline', () => {
   const x = shouldBlockPipeline(recurringIcs, new Date('2020-05-22T22:00:00.000Z'));
   expect(x && x.summary).toBe('RecurringBlock1');
 });
 
 // Test that the initial event in a recurring series blocks the pipeline when
 // the right edge aligns with the current time.
-test('current time aligns with the right edge of the first occurrence blocks pipeline', () => {
+test_('current time aligns with the right edge of the first occurrence blocks pipeline', () => {
   const x = shouldBlockPipeline(recurringIcs, new Date('2020-05-06T04:00:00.000Z'));
   expect(x && x.summary).toBe('RecurringBlock2');
 });
@@ -129,13 +134,13 @@ test('current time aligns with the right edge of the first occurrence blocks pip
 
 // Test that a future event in a recurring series blocks the pipeline when
 // the right edge aligns with the current time.
-test('current time aligns with the right edge of future event in series blocks pipeline', () => {
+test_('current time aligns with the right edge of future event in series blocks pipeline', () => {
   const x = shouldBlockPipeline(recurringIcs, new Date('2020-05-27T04:00:00.000Z'));
   expect(x && x.summary).toBe('RecurringBlock2');
 });
 
 // Test that we do not block between events in a recurring series.
-test('current time is between future events in recurring series does not block pipeline', () => {
+test_('current time is between future events in recurring series does not block pipeline', () => {
   const x = shouldBlockPipeline(recurringIcs, new Date('2020-05-14T00:00:00.000Z'));
   expect(x).toBeUndefined();
 });

--- a/lib/__tests__/registry-sync/ecr-mirror.test.ts
+++ b/lib/__tests__/registry-sync/ecr-mirror.test.ts
@@ -36,7 +36,7 @@ describe('EcrMirror', () => {
             Value: '123aass:password-key:AWSCURRENT',
           },
         ],
-        Image: 'jsii/superchain:1-buster-slim',
+        Image: 'public.ecr.aws/jsii/superchain:1-buster-slim',
         RegistryCredential: {
           Credential: '123aass',
           CredentialProvider: 'SECRETS_MANAGER',
@@ -55,7 +55,7 @@ describe('EcrMirror', () => {
               {
                 Ref: 'AWS::Region',
               },
-              '.amazonaws.com",\n        "docker pull library/docker-image:latest",\n        "docker tag library/docker-image:latest ',
+              '.amazonaws.com",\n        "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws",\n        "docker pull library/docker-image:latest",\n        "docker tag library/docker-image:latest ',
               {
                 Ref: 'AWS::AccountId',
               },

--- a/lib/__tests__/registry-sync/mirror-source.test.ts
+++ b/lib/__tests__/registry-sync/mirror-source.test.ts
@@ -75,12 +75,12 @@ describe(MirrorSource, () => {
     });
   });
 
-  describe(MirrorSource.fromImageName, () => {
+  describe(MirrorSource.fromPublicImage, () => {
     test('default', () => {
       // GIVEN
       const stack = new Stack();
       const ecrRegistry = 'myregistry';
-      const source = MirrorSource.fromImageName('jsii/superchain');
+      const source = MirrorSource.fromPublicImage('jsii/superchain');
 
       // WHEN
       const result = source.bind({
@@ -101,7 +101,7 @@ describe(MirrorSource, () => {
       // GIVEN
       const stack = new Stack();
       const ecrRegistry = 'myregistry';
-      const source = MirrorSource.fromImageName('public.ecr.aws/jsii/superchain', '1-buster-slim', 'jsii/superchain');
+      const source = MirrorSource.fromPublicImage('public.ecr.aws/jsii/superchain', '1-buster-slim', 'jsii/superchain');
 
       // WHEN
       const result = source.bind({
@@ -122,7 +122,7 @@ describe(MirrorSource, () => {
       // GIVEN
       const stack = new Stack();
       const ecrRegistry = 'myregistry';
-      const source = MirrorSource.fromImageName('jsii/superchain', 'mytag');
+      const source = MirrorSource.fromPublicImage('jsii/superchain', 'mytag');
 
       // WHEN
       const result = source.bind({
@@ -143,7 +143,7 @@ describe(MirrorSource, () => {
       // GIVEN
       const stack = new Stack();
       const ecrRegistry = 'myregistry';
-      const source = MirrorSource.fromImageName('superchain');
+      const source = MirrorSource.fromPublicImage('superchain');
 
       // WHEN
       const result = source.bind({
@@ -160,7 +160,7 @@ describe(MirrorSource, () => {
     });
 
     test('fails if image includes tag', () => {
-      expect(() => MirrorSource.fromImageName('superchain:latest')).toThrow(/image must not include tag/);
+      expect(() => MirrorSource.fromPublicImage('superchain:latest')).toThrow(/image must not include tag/);
     });
   });
 

--- a/lib/__tests__/registry-sync/mirror-source.test.ts
+++ b/lib/__tests__/registry-sync/mirror-source.test.ts
@@ -6,8 +6,8 @@ import {
 import { Template, Match } from 'aws-cdk-lib/assertions';
 import { MirrorSource } from '../../../lib/registry-sync';
 
-describe('RegistryImageSource', () => {
-  describe('fromDockerHub()', () => {
+describe(MirrorSource, () => {
+  describe(MirrorSource.fromDockerHub, () => {
     test('default', () => {
       // GIVEN
       const stack = new Stack();
@@ -75,7 +75,96 @@ describe('RegistryImageSource', () => {
     });
   });
 
-  describe('fromDirectory()', () => {
+  describe(MirrorSource.fromImageName, () => {
+    test('default', () => {
+      // GIVEN
+      const stack = new Stack();
+      const ecrRegistry = 'myregistry';
+      const source = MirrorSource.fromImageName('jsii/superchain');
+
+      // WHEN
+      const result = source.bind({
+        scope: stack,
+        ecrRegistry,
+      });
+
+      // THEN
+      expect(result.repositoryName).toEqual('jsii/superchain');
+      expect(result.tag).toEqual('latest');
+      expect(result.commands).toEqual([
+        'docker pull jsii/superchain:latest',
+        'docker tag jsii/superchain:latest myregistry/jsii/superchain:latest',
+      ]);
+    });
+
+    test('ECR Public image with custom output repository name', () => {
+      // GIVEN
+      const stack = new Stack();
+      const ecrRegistry = 'myregistry';
+      const source = MirrorSource.fromImageName('public.ecr.aws/jsii/superchain', '1-buster-slim', 'jsii/superchain');
+
+      // WHEN
+      const result = source.bind({
+        scope: stack,
+        ecrRegistry,
+      });
+
+      // THEN
+      expect(result.repositoryName).toEqual('jsii/superchain');
+      expect(result.tag).toEqual('1-buster-slim');
+      expect(result.commands).toEqual([
+        'docker pull public.ecr.aws/jsii/superchain:1-buster-slim',
+        'docker tag public.ecr.aws/jsii/superchain:1-buster-slim myregistry/jsii/superchain:1-buster-slim',
+      ]);
+    });
+
+    test('explicit tag', () => {
+      // GIVEN
+      const stack = new Stack();
+      const ecrRegistry = 'myregistry';
+      const source = MirrorSource.fromImageName('jsii/superchain', 'mytag');
+
+      // WHEN
+      const result = source.bind({
+        scope: stack,
+        ecrRegistry,
+      });
+
+      // THEN
+      expect(result.repositoryName).toEqual('jsii/superchain');
+      expect(result.tag).toEqual('mytag');
+      expect(result.commands).toEqual([
+        'docker pull jsii/superchain:mytag',
+        'docker tag jsii/superchain:mytag myregistry/jsii/superchain:mytag',
+      ]);
+    });
+
+    test('official image', () => {
+      // GIVEN
+      const stack = new Stack();
+      const ecrRegistry = 'myregistry';
+      const source = MirrorSource.fromImageName('superchain');
+
+      // WHEN
+      const result = source.bind({
+        scope: stack,
+        ecrRegistry,
+      });
+
+      // THEN
+      expect(result.repositoryName).toEqual('library/superchain');
+      expect(result.commands).toEqual([
+        'docker pull library/superchain:latest',
+        'docker tag library/superchain:latest myregistry/library/superchain:latest',
+      ]);
+    });
+
+    test('fails if image includes tag', () => {
+      expect(() => MirrorSource.fromImageName('superchain:latest')).toThrow(/image must not include tag/);
+    });
+  });
+
+  describe(MirrorSource.fromDir, () => {
     test('default', () => {
       // GIVEN
       const app = new App();

--- a/lib/registry-sync/ecr-mirror.ts
+++ b/lib/registry-sync/ecr-mirror.ts
@@ -206,15 +206,15 @@ export class EcrMirror extends Construct {
     }
   }
 
-  private createMirrorRepo(repositoryName: string) {
-    if (this._repos.get(repositoryName)) {
+  private createMirrorRepo(ecrRepositoryName: string) {
+    if (this._repos.get(ecrRepositoryName)) {
       return;
     }
 
-    const repository = new ecr.Repository(this, `Repo${repositoryName}`, {
-      repositoryName: repositoryName,
+    const repository = new ecr.Repository(this, `Repo${ecrRepositoryName}`, {
+      repositoryName: ecrRepositoryName,
     });
-    this._repos.set(repositoryName, repository);
+    this._repos.set(ecrRepositoryName, repository);
   }
 
   /**

--- a/lib/registry-sync/mirror-source.ts
+++ b/lib/registry-sync/mirror-source.ts
@@ -65,8 +65,22 @@ export abstract class MirrorSource {
    *
    * @param image e.g jsii/superchain
    * @param tag optional, defaults to 'latest'
+   *
+   * @deprecated This method's name inaccurately expresses that the image comes
+   * from DockerHub, when any publicly-accessible repository can be used. Prefer
+   * using `fromImageName(string, string?)` instead, which is more aptly named.
    */
   public static fromDockerHub(image: string, tag: string = 'latest'): MirrorSource {
+    return this.fromImageName(image, tag);
+  }
+
+  /**
+   * Configure an image from DockerHub or a repository-qualified image name.
+   *
+   * @param image e.g public.ecr.aws/jsii/superchain
+   * @param tag optional, defaults to 'latest'
+   */
+  public static fromImageName(image: string, tag: string = 'latest'): MirrorSource {
     class DockerHubMirrorSource extends MirrorSource {
       constructor() {
         if (image.includes(':')) {

--- a/lib/registry-sync/mirror-source.ts
+++ b/lib/registry-sync/mirror-source.ts
@@ -79,8 +79,9 @@ export abstract class MirrorSource {
    *
    * @param image e.g public.ecr.aws/jsii/superchain
    * @param tag optional, defaults to 'latest'
+   * @param ecrRepositoryName the name of the ECR Repository to use (e.g: jsii/superchain)
    */
-  public static fromImageName(image: string, tag: string = 'latest'): MirrorSource {
+  public static fromImageName(image: string, tag: string = 'latest', ecrRepositoryName: string = image.includes('/') ? image : `library/${image}`): MirrorSource {
     class DockerHubMirrorSource extends MirrorSource {
       constructor() {
         if (image.includes(':')) {
@@ -88,17 +89,17 @@ export abstract class MirrorSource {
         }
         // simulates DockerHub by perfixing library/ to official images
         const repositoryName = image.includes('/') ? image : `library/${image}`;
-        super(repositoryName, tag, undefined);
+        super(repositoryName, tag, undefined, ecrRepositoryName);
       }
 
-      public bind(options: MirrorSourceBindOptions) {
-        const ecrImageUri = `${options.ecrRegistry}/${this.repositoryName}:${this.tag}`;
+      public bind(options: MirrorSourceBindOptions): MirrorSourceConfig {
+        const ecrImageUri = `${options.ecrRegistry}/${this.ecrRepositoryName}:${this.tag}`;
         return {
           commands: [
             `docker pull ${this.repositoryName}:${this.tag}`,
             `docker tag ${this.repositoryName}:${this.tag} ${ecrImageUri}`,
           ],
-          repositoryName: this.repositoryName,
+          repositoryName: this.ecrRepositoryName,
           tag: this.tag,
         };
       }
@@ -128,12 +129,12 @@ export abstract class MirrorSource {
         super(repositoryName, opts.tag ?? 'latest', directory);
       }
 
-      public bind(options: MirrorSourceBindOptions) {
+      public bind(options: MirrorSourceBindOptions): MirrorSourceConfig {
         const asset = new s3Assets.Asset(options.scope, `BuildContext${this.directory}${JSON.stringify(opts.buildArgs ?? {})}`, { path: this.directory! });
         if (options.syncJob) {
           asset.grantRead(options.syncJob);
         }
-        const ecrImageUri = `${options.ecrRegistry}/${this.repositoryName}:${this.tag}`;
+        const ecrImageUri = `${options.ecrRegistry}/${this.ecrRepositoryName}:${this.tag}`;
         const cmdFlags = [];
         cmdFlags.push('--pull');
         cmdFlags.push('-t', ecrImageUri);
@@ -152,7 +153,7 @@ export abstract class MirrorSource {
             `unzip ${zipFile} -d ${tmpDir}`,
             `docker build ${cmdFlags.join(' ')} ${tmpDir}`,
           ],
-          repositoryName: this.repositoryName,
+          repositoryName: this.ecrRepositoryName,
           tag: this.tag,
         };
       }
@@ -160,7 +161,12 @@ export abstract class MirrorSource {
     return new DirectoryMirrorSource();
   }
 
-  private constructor(protected readonly repositoryName: string, protected readonly tag: string, protected readonly directory?: string) {
+  private constructor(
+    protected readonly repositoryName: string,
+    protected readonly tag: string,
+    protected readonly directory?: string,
+    protected readonly ecrRepositoryName = repositoryName,
+  ) {
   }
 
   /**

--- a/lib/registry-sync/mirror-source.ts
+++ b/lib/registry-sync/mirror-source.ts
@@ -71,7 +71,7 @@ export abstract class MirrorSource {
    * using `fromImageName(string, string?)` instead, which is more aptly named.
    */
   public static fromDockerHub(image: string, tag: string = 'latest'): MirrorSource {
-    return this.fromImageName(image, tag);
+    return this.fromPublicImage(image, tag);
   }
 
   /**
@@ -81,7 +81,7 @@ export abstract class MirrorSource {
    * @param tag optional, defaults to 'latest'
    * @param ecrRepositoryName the name of the ECR Repository to use (e.g: jsii/superchain)
    */
-  public static fromImageName(image: string, tag: string = 'latest', ecrRepositoryName: string = image.includes('/') ? image : `library/${image}`): MirrorSource {
+  public static fromPublicImage(image: string, tag: string = 'latest', ecrRepositoryName: string = image.includes('/') ? image : `library/${image}`): MirrorSource {
     class DockerHubMirrorSource extends MirrorSource {
       constructor() {
         if (image.includes(':')) {


### PR DESCRIPTION
This affords an increased rate limit for pulls. Additionally, switch to using the `public.ecr.aws/jsii/superchain` image instead of pulling it from DockerHub, and clarify the MirrorImage doesn't need to come from DockerBug by introducing an alternate (and improved) static factory.

In orde to enable reducing the scope of changes incurred by migrating from DockerHub images to using their equivalent ECR-Public URL, allows configuring a custom ECR Repository name to be used on the output side.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.