### PR TITLE
fix: update all default codebuild images to Standard 6

### DIFF
--- a/lib/publishing.ts
+++ b/lib/publishing.ts
@@ -162,7 +162,7 @@ export class PublishToNpmProject extends Construct implements IPublisher {
     const access = props.access ?? NpmAccess.PUBLIC;
 
     const shellable = new Shellable(this, 'Default', {
-      platform: new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_5_0),
+      platform: new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_6_0),
       scriptDirectory: path.join(__dirname, 'publishing', 'npm'),
       entrypoint: 'publish.sh',
       environment: {
@@ -322,7 +322,7 @@ export class PublishDocsToGitHubProject extends Construct implements IPublisher 
     const forReal = props.dryRun === undefined ? 'false' : (!props.dryRun).toString();
 
     const shellable = new Shellable(this, 'Default', {
-      platform: new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_5_0),
+      platform: new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_6_0),
       scriptDirectory: path.join(__dirname, 'publishing', 'docs'),
       entrypoint: 'publish.sh',
       environment: {
@@ -427,7 +427,7 @@ export class PublishToGitHub extends Construct implements IPublisher {
     }
 
     const shellable = new Shellable(this, 'Default', {
-      platform: new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_5_0),
+      platform: new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_6_0),
       scriptDirectory: path.join(__dirname, 'publishing', 'github'),
       entrypoint: 'publish.sh',
       environment: noUndefined({
@@ -494,7 +494,7 @@ export class PublishToS3 extends Construct implements IPublisher {
     const forReal = props.dryRun === undefined ? 'false' : (!props.dryRun).toString();
 
     const shellable = new Shellable(this, 'Default', {
-      platform: new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_5_0),
+      platform: new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_6_0),
       scriptDirectory: path.join(__dirname, 'publishing', 's3'),
       entrypoint: 'publish.sh',
       environment: {
@@ -548,7 +548,7 @@ export class PublishToPyPi extends Construct {
     const forReal = props.dryRun === undefined ? 'false' : (!props.dryRun).toString();
 
     const shellable = new Shellable(this, 'Default', {
-      platform: new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_5_0),
+      platform: new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_6_0),
       scriptDirectory: path.join(__dirname, 'publishing', 'pypi'),
       entrypoint: 'publish.sh',
       environment: {
@@ -639,7 +639,7 @@ export class PublishToGolang extends Construct {
     const dryRun = props.dryRun ?? false;
 
     const shellable = new Shellable(this, 'Default', {
-      platform: new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_5_0),
+      platform: new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_6_0),
       scriptDirectory: path.join(__dirname, 'publishing', 'golang'),
       entrypoint: 'publish.sh',
       environment: {

--- a/lib/shellable.ts
+++ b/lib/shellable.ts
@@ -373,7 +373,7 @@ export abstract class ShellPlatform {
    */
   public static get LinuxUbuntu(): ShellPlatform {
     // Cannot be static member because of initialization order
-    return new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_4_0);
+    return new LinuxPlatform(cbuild.LinuxBuildImage.STANDARD_6_0);
   }
 
   /**


### PR DESCRIPTION
Standard 5 has been placed in the slow download path (i.e., **not** precached on the CodeBuild hosts), so move everything to Standard 6.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.