### PR TITLE
fix: ecr-mirror code build fails to start

### DIFF
--- a/lib/__tests__/registry-sync/ecr-mirror.test.ts
+++ b/lib/__tests__/registry-sync/ecr-mirror.test.ts
@@ -37,10 +37,6 @@ describe('EcrMirror', () => {
           },
         ],
         Image: 'public.ecr.aws/jsii/superchain:1-buster-slim-node18',
-        RegistryCredential: {
-          Credential: '123aass',
-          CredentialProvider: 'SECRETS_MANAGER',
-        },
       },
       Source: {
         BuildSpec: {

--- a/lib/registry-sync/ecr-mirror.ts
+++ b/lib/registry-sync/ecr-mirror.ts
@@ -103,9 +103,7 @@ export class EcrMirror extends Construct {
     this._project = new codebuild.Project(this, 'EcrPushImages', {
       environment: {
         privileged: true,
-        buildImage: codebuild.LinuxBuildImage.fromDockerRegistry('public.ecr.aws/jsii/superchain:1-buster-slim-node18', {
-          secretsManagerCredentials: props.dockerHubCredentials.secret,
-        }),
+        buildImage: codebuild.LinuxBuildImage.fromDockerRegistry('public.ecr.aws/jsii/superchain:1-buster-slim-node18'),
       },
       environmentVariables: {
         // DockerHub credentials to avoid throttling
@@ -145,6 +143,10 @@ export class EcrMirror extends Construct {
 
     // Ensure the runner has PULL access to ECR-Public.
     this._project.role!.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonElasticContainerRegistryPublicReadOnly'));
+
+    // Give the project access to the Docker Hub credentials
+    // Required for access to private images and to avoid throttling of unauthorized requests
+    props.dockerHubCredentials.secret.grantRead(this._project);
 
     for (const image of props.sources) {
       const result = image.bind({


### PR DESCRIPTION
The build image was changed to use jsii/superchain from the Public Amazon ECR, but this doesn't work when `RegistryCredential` is configured. This behavior is documented (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-environment.html#cfn-codebuild-project-environment-registrycredential)


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.