### PR TITLE
feat: update sign.sh for NuGet signer migration

### DIFF
--- a/lib/publishing/nuget/sign.sh
+++ b/lib/publishing/nuget/sign.sh
@@ -1,10 +1,31 @@
 #!/bin/bash
-set -euo pipefail
 
 if [ $# -ne 1 ]
 then
   echo "Usage: $0 <nuget-package.nupkg>"
   exit -1
+fi
+
+if [[ "${FOR_REAL:-}" == "true" ]]
+then
+  echo "============================================================================"
+  echo "Executing in production environment"
+  echo
+  echo "Set environment variable FOR_REAL=false for development environment!"
+  echo "============================================================================"
+  ENV="prod"
+else
+  echo "============================================================================"
+  echo "Executing in development environment"
+  echo
+  echo "While in development you must set the following environment variables:"
+  echo "  1. SIGNER_ACCESS_ROLE_ARN"
+  echo "  2. SIGNING_BUCKET_NAME"
+  echo "  3. SIGNING_LAMBDA_NAME"
+  echo
+  echo "Set environment variable FOR_REAL=true for production environment!"
+  echo "============================================================================"
+  ENV="dev"
 fi
 
 echo "Installing required CLI tools: jq"
@@ -17,64 +38,78 @@ else
     echo "!!! Neither an apt nor yum distribution - could not install jq, things might break!"
 fi
 
+if [ -n "${SIGNER_ACCESS_ROLE_ARN:-}" ]; then
+  ROLE=$(aws sts assume-role --role-arn "${SIGNER_ACCESS_ROLE_ARN:-}" --role-session-name "signer_access")
+  export AWS_ACCESS_KEY_ID=$(echo $ROLE | jq -r .Credentials.AccessKeyId)
+  export AWS_SECRET_ACCESS_KEY=$(echo $ROLE | jq -r .Credentials.SecretAccessKey)
+  export AWS_SESSION_TOKEN=$(echo $ROLE | jq -r .Credentials.SessionToken)
+fi
+
 NUGET_PACKAGE=$(cd $(dirname $1) && echo $PWD)/$(basename $1)
-SIGNING_BUCKET_NAME='cdk-signing-bucket'
-SIGNING_LAMBDA_NAME='cdk-signing-lambda'
 
-##############################################################################
-# Code for development - testing with .zip files
-##############################################################################
-echo "🔑 Applying authenticode signatures to assemblies in ${NUGET_PACKAGE}"
-for FILE in ${NUGET_PACKAGE}/*.zip
-do
-  echo "📄 Assembly: ${FILE}"
-  TMP=$(mktemp -d)
-  # upload DLL to signing bucket
-  VERSION_ID=$(aws s3api put-object \
-    --bucket ${SIGNING_BUCKET_NAME} \
-    --key unsigned/${FILE} \
-    --body ${FILE} | jq -r '.VersionId')
-  # invoke signing lambda
-  aws lambda invoke \
-    --function-name ${SIGNING_LAMBDA_NAME} \
-    --invocation-type RequestResponse \
-    --cli-binary-format raw-in-base64-out \
-    --payload '{ "artifactKey": "'"unsigned/${FILE}"'", "artifactVersion": "'"${VERSION_ID}"'" }' \
-    ${TMP}/response.json
-  SIGNED_ARTIFACT_KEY=$(cat ${TMP}/response.json | jq -r '.signedArtifactKey')
-  # download signed DLL from signing bucket
-  aws s3api get-object \
-    --bucket ${SIGNING_BUCKET_NAME} \
-    --key ${SIGNED_ARTIFACT_KEY} \
-    nuget-package-signed/artifact.zip
-  rm -rf ${TMP}
-done
+echo echo "🔑 Applying authenticode signatures to assemblies in ${NUGET_PACKAGE}"
+if [[ "${ENV}" == "dev" ]]
+then
+  for file in ${NUGET_PACKAGE}/*.zip
+  do
+    echo "📄 Assembly: ${file}"
+    tmp=$(mktemp -d)
+    # upload zip to signer bucket
+    version_id=$(aws s3api put-object \
+      --bucket ${SIGNING_BUCKET_NAME:-} \
+      --key unsigned/${file} \
+      --body ${file} | jq -r '.VersionId' )
+    # invoke signer lambda
+    aws lambda invoke \
+      --function-name ${SIGNING_LAMBDA_NAME:-} \
+      --invocation-type RequestResponse \
+      --cli-binary-format raw-in-base64-out \
+      --payload '{ "artifactKey": "'"unsigned/${file}"'", "artifactVersion": "'"${version_id}"'" }' \
+      ${tmp}/response.json
+    signed_artifact_key=$(cat ${tmp}/response.json | jq -r '.signedArtifactKey')
+    # download signed zip from signer bucket
+    aws s3api get-object \
+      --bucket ${SIGNING_BUCKET_NAME:-} \
+      --key ${signed_artifact_key} \
+      nuget-package-signed/artifact.zip
+    # clean up temporary directory
+    rm -rf ${tmp}
+  done
+else
+  for file in $(unzip -Z1 ${NUGET_PACKAGE} '*dll')
+  do
+    echo "📄 Assembly: ${file}"
+    tmp=$(mktemp -d)
+    # extract the dll from the zip file
+    unzip -q ${NUGET_PACKAGE} -d ${tmp} ${file}
+    # need to set appropriate permissions, otherwise the file has none
+    chmod u+rw ${tmp}/${file}
+    # upload dll to signer bucket
+    version_id=$(aws s3api put-object \
+      --bucket ${SIGNING_BUCKET_NAME:-} \
+      --key unsigned/${file} \
+      --body ${file} | jq -r '.VersionId' )
+    # invoke signer lambda
+    aws lambda invoke \
+      --function-name ${SIGNING_LAMBDA_NAME:-} \
+      --invocation-type RequestResponse \
+      --cli-binary-format raw-in-base64-out \
+      --payload '{ "artifactKey": "'"unsigned/${file}"'", "artifactVersion": "'"${version_id}"'" }' \
+      ${tmp}/response.json
+    signed_artifact_key=$(cat ${tmp}/response.json | jq -r '.signedArtifactKey')
+    # download signed dll from signer bucket
+    aws s3api get-object \
+      --bucket ${SIGNING_BUCKET_NAME:-} \
+      --key ${signed_artifact_key} \
+      ${tmp}/${file}
+    # replace the dll in the nuget package
+    (
+      cd ${tmp}
+      zip -qfr ${NUGET_PACKAGE} ${file}
+    )
+    # clean up temporary directory
+    rm -rf ${tmp}
+  done
+fi
 echo "🔐 All Done!"
-
-##############################################################################
-# Code for production - will use .dll files - NOT COMPLETE
-##############################################################################
-# echo "🔑 Applying authenticode signatures to assemblies in ${NUGET_PACKAGE}"
-# for FILE in $(unzip -Z1 ${NUGET_PACKAGE} '*dll')
-# do
-#   echo "📄 Assembly: ${FILE}"
-#   TMP=$(mktemp -d)
-#   # extract the DLL from the ZIP file
-#   unzip -q ${NUGET_PACKAGE} -d ${TMP} ${FILE}
-#   chmod u+rw ${TMP}/${FILE}
-#   # upload DLL to signing bucket
-#   VERSION_ID=$(aws s3api put-object \
-#     --bucket ${SIGNING_BUCKET_NAME} \
-#     --key unsigned/${FILE} \
-#     --body ${TMP}/${FILE} | jq -r '.VersionId')
-#   # invoke signing lambda
-#   aws lambda invoke \
-#     --function-name ${SIGNING_LAMBDA_NAME} \
-#     --invocation-type Event \
-#     --cli-binary-format raw-in-base64-out \
-#     --payload '{ "artifactKey": "'"unsigned/${FILE}"'", "artifactVersion": "'"${VERSION_ID}"'" }' \
-#     response.json
-#   # download signed DLL from S3
-# done
-# echo "🔐 All Done!"
 

--- a/lib/publishing/nuget/sign.sh
+++ b/lib/publishing/nuget/sign.sh
@@ -1,37 +1,80 @@
 #!/bin/bash
 set -euo pipefail
 
-if [ $# -ne 4 ]
+if [ $# -ne 1 ]
 then
-  echo "Usage: $0 <nuget-package.nupkg> <certificate.spc> <privatekey.pvk> <timestamp-url>"
+  echo "Usage: $0 <nuget-package.nupkg>"
   exit -1
 fi
-NUGET_PACKAGE=$(cd $(dirname $1) && echo $PWD)/$(basename $1)
-SOFTWARE_PUBLISHER_CERTIFICATE=$2
-PRIVATE_KEY=$3
-TIMESTAMP_URL=$4
 
+echo "Installing required CLI tools: jq"
+if command -v yum &>/dev/null; then
+    yum install -y jq
+elif command -v apt-get &>/dev/null; then
+    apt-get update
+    apt-get install -y jq
+else
+    echo "!!! Neither an apt nor yum distribution - could not install jq, things might break!"
+fi
+
+NUGET_PACKAGE=$(cd $(dirname $1) && echo $PWD)/$(basename $1)
+SIGNING_BUCKET_NAME='cdk-signing-bucket'
+SIGNING_LAMBDA_NAME='cdk-signing-lambda'
+
+##############################################################################
+# Code for development - testing with .zip files
+##############################################################################
 echo "🔑 Applying authenticode signatures to assemblies in ${NUGET_PACKAGE}"
-for FILE in $(unzip -Z1 ${NUGET_PACKAGE} '*.dll')
+for FILE in ${NUGET_PACKAGE}/*.zip
 do
-  echo "📄 Assemby: ${FILE}"
+  echo "📄 Assembly: ${FILE}"
   TMP=$(mktemp -d)
-  # Extract the DLL from the ZIP file
-  unzip -q ${NUGET_PACKAGE} -d ${TMP} ${FILE}
-  # Need to set appropriate permissions, otherwise the file has none.
-  chmod u+rw ${TMP}/${FILE}
-  # Sign the DLL
-  signcode  -a    sha256                                                        \
-            -spc  ${SOFTWARE_PUBLISHER_CERTIFICATE}                             \
-            -v    ${PRIVATE_KEY}                                                \
-            -t    ${TIMESTAMP_URL}                                              \
-            ${TMP}/${FILE}
-  # Replace the DLL in the NuGet package
-  (
-    cd ${TMP} # Need to step in so the TMP prefix isn't mirrored in the ZIP -_-
-    zip -qfr ${NUGET_PACKAGE} ${FILE}
-  )
-  # Clean up temporary directory
-  rm -fr ${TMP}
+  # upload DLL to signing bucket
+  VERSION_ID=$(aws s3api put-object \
+    --bucket ${SIGNING_BUCKET_NAME} \
+    --key unsigned/${FILE} \
+    --body ${FILE} | jq -r '.VersionId')
+  # invoke signing lambda
+  aws lambda invoke \
+    --function-name ${SIGNING_LAMBDA_NAME} \
+    --invocation-type RequestResponse \
+    --cli-binary-format raw-in-base64-out \
+    --payload '{ "artifactKey": "'"unsigned/${FILE}"'", "artifactVersion": "'"${VERSION_ID}"'" }' \
+    ${TMP}/response.json
+  SIGNED_ARTIFACT_KEY=$(cat ${TMP}/response.json | jq -r '.signedArtifactKey')
+  # download signed DLL from signing bucket
+  aws s3api get-object \
+    --bucket ${SIGNING_BUCKET_NAME} \
+    --key ${SIGNED_ARTIFACT_KEY} \
+    nuget-package-signed/artifact.zip
+  rm -rf ${TMP}
 done
 echo "🔐 All Done!"
+
+##############################################################################
+# Code for production - will use .dll files - NOT COMPLETE
+##############################################################################
+# echo "🔑 Applying authenticode signatures to assemblies in ${NUGET_PACKAGE}"
+# for FILE in $(unzip -Z1 ${NUGET_PACKAGE} '*dll')
+# do
+#   echo "📄 Assembly: ${FILE}"
+#   TMP=$(mktemp -d)
+#   # extract the DLL from the ZIP file
+#   unzip -q ${NUGET_PACKAGE} -d ${TMP} ${FILE}
+#   chmod u+rw ${TMP}/${FILE}
+#   # upload DLL to signing bucket
+#   VERSION_ID=$(aws s3api put-object \
+#     --bucket ${SIGNING_BUCKET_NAME} \
+#     --key unsigned/${FILE} \
+#     --body ${TMP}/${FILE} | jq -r '.VersionId')
+#   # invoke signing lambda
+#   aws lambda invoke \
+#     --function-name ${SIGNING_LAMBDA_NAME} \
+#     --invocation-type Event \
+#     --cli-binary-format raw-in-base64-out \
+#     --payload '{ "artifactKey": "'"unsigned/${FILE}"'", "artifactVersion": "'"${VERSION_ID}"'" }' \
+#     response.json
+#   # download signed DLL from S3
+# done
+# echo "🔐 All Done!"
+

--- a/lib/publishing/nuget/sign.sh
+++ b/lib/publishing/nuget/sign.sh
@@ -58,20 +58,20 @@ then
     version_id=$(aws s3api put-object \
       --bucket ${SIGNING_BUCKET_NAME:-} \
       --key unsigned/${file} \
-      --body ${file} | jq -r '.VersionId' )
+      --body ${file} | jq -r '.VersionId')
     # invoke signer lambda
     aws lambda invoke \
       --function-name ${SIGNING_LAMBDA_NAME:-} \
       --invocation-type RequestResponse \
       --cli-binary-format raw-in-base64-out \
       --payload '{ "artifactKey": "'"unsigned/${file}"'", "artifactVersion": "'"${version_id}"'" }' \
-      ${tmp}/response.json
+      ${tmp}/response.json >/dev/null
     signed_artifact_key=$(cat ${tmp}/response.json | jq -r '.signedArtifactKey')
     # download signed zip from signer bucket
     aws s3api get-object \
       --bucket ${SIGNING_BUCKET_NAME:-} \
       --key ${signed_artifact_key} \
-      nuget-package-signed/artifact.zip
+      nuget-package-signed/artifact.zip >/dev/null
     # clean up temporary directory
     rm -rf ${tmp}
   done
@@ -88,20 +88,20 @@ else
     version_id=$(aws s3api put-object \
       --bucket ${SIGNING_BUCKET_NAME:-} \
       --key unsigned/${file} \
-      --body ${file} | jq -r '.VersionId' )
+      --body ${file} | jq -r '.VersionId')
     # invoke signer lambda
     aws lambda invoke \
       --function-name ${SIGNING_LAMBDA_NAME:-} \
       --invocation-type RequestResponse \
       --cli-binary-format raw-in-base64-out \
       --payload '{ "artifactKey": "'"unsigned/${file}"'", "artifactVersion": "'"${version_id}"'" }' \
-      ${tmp}/response.json
+      ${tmp}/response.json >/dev/null
     signed_artifact_key=$(cat ${tmp}/response.json | jq -r '.signedArtifactKey')
     # download signed dll from signer bucket
     aws s3api get-object \
       --bucket ${SIGNING_BUCKET_NAME:-} \
       --key ${signed_artifact_key} \
-      ${tmp}/${file}
+      ${tmp}/${file} >/dev/null
     # replace the dll in the nuget package
     (
       cd ${tmp}

--- a/lib/publishing/nuget/sign.sh
+++ b/lib/publishing/nuget/sign.sh
@@ -47,7 +47,7 @@ fi
 
 NUGET_PACKAGE=$(cd $(dirname $1) && echo $PWD)/$(basename $1)
 
-echo echo "🔑 Applying authenticode signatures to assemblies in ${NUGET_PACKAGE}"
+echo "🔑 Applying authenticode signatures to assemblies in ${NUGET_PACKAGE}"
 if [[ "${ENV}" == "dev" ]]
 then
   for file in ${NUGET_PACKAGE}/*.zip


### PR DESCRIPTION
Very much a WIP!

The current code is being used to test that sign.sh can make the correct API calls into the signer account. This is using .zip files until we can test with .dll files.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.