### PR TITLE
feat: add mutable `defaultArtifact` attribute to `Pipeline` class to use as default `inputArtifact` for all pipeline stages following build or sign stage

### DIFF
--- a/lib/__tests__/pipeline.test.ts
+++ b/lib/__tests__/pipeline.test.ts
@@ -345,7 +345,7 @@ test('signing output artifact is used as input artifact for all stages after sig
   const stack = new Stack(app, 'TestStack');
   const signingLambda = Function.fromFunctionName(stack, 'SigningLambda', 'signing-lambda');
   const signingBucket = Bucket.fromBucketName(stack, 'SigningBucket', 'signing-bucket');
-  const signingAccessRole = Role.fromRoleName(stack, 'SigningAccessRole', 'signing-access-role');
+  const accessRole = Role.fromRoleName(stack, 'AccessRole', 'access-role');
   const pipeline = new delivlib.Pipeline(stack, 'Pipeline', {
     repo: createTestRepo(stack),
     pipelineName: 'TestPipeline',
@@ -355,12 +355,12 @@ test('signing output artifact is used as input artifact for all stages after sig
   pipeline.signNuGetWithSigner({
     signingLambda,
     signingBucket,
-    signingAccessRole,
+    accessRole,
   });
 
-  pipeline.publishToNpm({
-    npmTokenSecret: {
-      secretArn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:npm-token-secret',
+  pipeline.publishToNuGet({
+    nugetApiKeySecret: {
+      secretArn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:nuget-secret',
     },
   });
 

--- a/lib/__tests__/signing.test.ts
+++ b/lib/__tests__/signing.test.ts
@@ -23,13 +23,13 @@ describe('with standard pipeline', () => {
     // GIVEN
     const signingBucket = Bucket.fromBucketName(stack, 'SigningBucket', 'signing-bucket');
     const signingLambda = Function.fromFunctionName(stack, 'SigningLambda', 'signing-lambda');
-    const signingAccessRole = Role.fromRoleName(stack, 'SigningAccessRole', 'signing-access-role');
+    const accessRole = Role.fromRoleName(stack, 'AccessRole', 'access-role');
 
     // WHEN
     pipeline.signNuGetWithSigner({
       signingBucket,
       signingLambda,
-      signingAccessRole,
+      accessRole,
     });
 
     // THEN
@@ -51,7 +51,7 @@ describe('with standard pipeline', () => {
           {
             Name: 'SCRIPT_S3_KEY',
             Type: 'PLAINTEXT',
-            Value: '1ccec5da3e38e2c229307a68b2feb159deb67f714ce2209b3c680115486b707f.zip',
+            Value: '304990045086f467d5effaa1d1aa90d3f19411750a41f9cb37ab387399f92e39.zip',
           },
           {
             Name: 'SIGNING_BUCKET_NAME',
@@ -83,7 +83,7 @@ describe('with standard pipeline', () => {
             },
           },
           {
-            Name: 'SIGNING_ACCESS_ROLE_ARN',
+            Name: 'ACCESS_ROLE_ARN',
             Type: 'PLAINTEXT',
             Value: {
               'Fn::Join': [
@@ -97,7 +97,7 @@ describe('with standard pipeline', () => {
                   {
                     Ref: 'AWS::AccountId',
                   },
-                  ':role/signing-access-role',
+                  ':role/access-role',
                 ],
               ],
             },

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -27,7 +27,7 @@ import * as signing from './signing';
 import { determineRunOrder, flatMap } from './util';
 
 const PUBLISH_STAGE_NAME = 'Publish';
-const SIGINING_STAGE_NAME = 'Sign';
+const SIGNING_STAGE_NAME = 'Sign';
 const TEST_STAGE_NAME = 'Test';
 const METRIC_NAMESPACE = 'CDK/Delivlib';
 const FAILURE_METRIC_NAME = 'Failures';
@@ -370,7 +370,7 @@ export class Pipeline extends Construct {
   }
 
   public addSigning(signer: signing.ISigner, options: signing.AddSigningOptions = {}) {
-    const signingStageName = options.stageName ?? SIGINING_STAGE_NAME;
+    const signingStageName = options.stageName ?? SIGNING_STAGE_NAME;
     const stage = this.getOrCreateStage(signingStageName);
 
     this._signingOutput = signer.addToPipeline(stage, `${signer.node.id}Sign`, {

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -626,7 +626,9 @@ export interface AddPublishOptions {
   /**
    * The input artifact to use
    *
-   * @default Build output artifact
+   * @default Signing output artifact when a signing stage is added to the
+   * pipeline via `addSigning` or `signNuGetWithSigner`. Otherwise, the default
+   * will be the build output artifact.
    */
   inputArtifact?: cpipeline.Artifact;
 
@@ -663,7 +665,9 @@ export interface AddShellableOptions extends ShellableProps {
   /**
    * The input artifact to use
    *
-   * @default Build output artifact
+   * @default Signing output artifact when a signing stage is added to the
+   * pipeline via `addSigning` or `signNuGetWithSigner`. Otherwise, the default
+   * will be the build output artifact.
    */
   inputArtifact?: cpipeline.Artifact;
 }

--- a/lib/signing.ts
+++ b/lib/signing.ts
@@ -44,7 +44,7 @@ export interface SignNuGetWithSignerProps {
   /**
    * A role used provide access to the signing bucket and signing lambda
    */
-  readonly signingAccessRole: IRole;
+  readonly accessRole: IRole;
 
   /**
    * The build image to do the signing in
@@ -66,7 +66,7 @@ export class SignNuGetWithSigner extends Construct implements ISigner {
     const environment = {
       SIGNING_BUCKET_NAME: props.signingBucket.bucketName,
       SIGNING_LAMBDA_ARN: props.signingLambda.functionArn,
-      SIGNING_ACCESS_ROLE_ARN: props.signingAccessRole.roleArn,
+      ACCESS_ROLE_ARN: props.accessRole.roleArn,
     };
 
     const shellable = new Shellable(this, 'Default', {

--- a/lib/signing/nuget/sign.sh
+++ b/lib/signing/nuget/sign.sh
@@ -11,8 +11,8 @@ else
     echo "!!! Neither an apt nor yum distribution - could not install jq, things might break!"
 fi
 
-if [ -n "${SIGNING_ACCESS_ROLE_ARN:-}" ]; then
-  ROLE=$(aws sts assume-role --role-arn "${SIGNING_ACCESS_ROLE_ARN:-}" --role-session-name "signer_access")
+if [ -n "${ACCESS_ROLE_ARN:-}" ]; then
+  ROLE=$(aws sts assume-role --role-arn "${ACCESS_ROLE_ARN:-}" --role-session-name "signer_access")
   export AWS_ACCESS_KEY_ID=$(echo $ROLE | jq -r .Credentials.AccessKeyId)
   export AWS_SECRET_ACCESS_KEY=$(echo $ROLE | jq -r .Credentials.SecretAccessKey)
   export AWS_SESSION_TOKEN=$(echo $ROLE | jq -r .Credentials.SessionToken)


### PR DESCRIPTION
This PR adds a `defaultArtifact` attribute to the `Pipeline` class. The `defaultArtifact` attribute will act as the default `inputArtifact` based on the following conditions:
1. If a signing stage is not added, then the `defaultArtifact` for all stages following the build stage will be the `buildOutput` artifact
2. If a signing stage is added to the `Pipeline` via `signNuGetWithSigner` or `addSigning`, then the `defaultArtifact` for all stages following the sign stage will be the `signingOutput` artifact

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.