### PR TITLE
feat: expose service role to allow custom codebuild role for shellables

### DIFF
--- a/lib/shellable.ts
+++ b/lib/shellable.ts
@@ -6,6 +6,7 @@ import {
   aws_codepipeline as cpipeline, aws_codepipeline_actions as cpipeline_actions,
   aws_iam as iam, aws_s3_assets as assets, aws_secretsmanager, aws_ssm,
 } from 'aws-cdk-lib';
+import { IRole } from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 import { BuildSpec } from './build-spec';
 import { renderEnvironmentVariables } from './util';
@@ -153,6 +154,13 @@ export interface ShellableOptions {
    * @default No environment variables
    */
   readonly pipelineEnvironmentVars?: Record<string, string>;
+
+  /**
+   * The service role to assume while running the build
+   *
+   * @default A role will be created
+   */
+  readonly serviceRole?: IRole;
 }
 
 /**

--- a/lib/shellable.ts
+++ b/lib/shellable.ts
@@ -318,6 +318,7 @@ export class Shellable extends Construct {
       projectName: props.buildProjectName,
       description: props.description,
       source: props.source,
+      role: props.serviceRole,
       environment: {
         buildImage: this.platform.buildImage,
         computeType: props.computeType || cbuild.ComputeType.MEDIUM,

--- a/lib/signing.ts
+++ b/lib/signing.ts
@@ -81,6 +81,7 @@ export class SignNuGetWithSigner extends Construct implements ISigner {
       platform: new LinuxPlatform(props.buildImage ?? LinuxBuildImage.fromDockerRegistry('public.ecr.aws/jsii/superchain:1-buster-slim-node18')),
       scriptDirectory: path.join(__dirname, 'signing', 'nuget'),
       entrypoint: 'sign.sh',
+      serviceRole: props.serviceRole,
       buildSpec: BuildSpec.literal({
         version: '0.2',
         artifacts: {

--- a/lib/signing.ts
+++ b/lib/signing.ts
@@ -47,6 +47,14 @@ export interface SignNuGetWithSignerProps {
   readonly accessRole: IRole;
 
   /**
+   * The service role that will be used to allow CodeBuild to perform operations
+   * on your behalf.
+   *
+   * @default A role will be created
+   */
+  readonly serviceRole?: IRole;
+
+  /**
    * The build image to do the signing in
    *
    * Needs to have NuGet preinstalled.


### PR DESCRIPTION
This PR exposes the underlying `role` property used to specify a role to be used by the CodeBuild project created as part of creating a new `Shellable`

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.