### PR TITLE
feat: add props on `SignNuGetWithSignerProps` for signer profile and signer owner

### DIFF
--- a/lib/__tests__/signing.test.ts
+++ b/lib/__tests__/signing.test.ts
@@ -243,7 +243,7 @@ describe('with standard pipeline', () => {
     const signingBucket = Bucket.fromBucketName(stack, 'SigningBucket', 'signing-bucket');
     const signingLambda = Function.fromFunctionName(stack, 'SigningLambda', 'signing-lambda');
     const accessRole = Role.fromRoleName(stack, 'AccessRole', 'access-role');
-    
+
     // WHEN
     pipeline.signNuGetWithSigner({
       signingBucket,
@@ -252,7 +252,7 @@ describe('with standard pipeline', () => {
       signerProfileName: 'test-profile-name',
       signerProfileOwner: 'test-profile-owner',
     });
-    
+
     // THEN
     Template.fromStack(stack).hasResourceProperties('AWS::CodeBuild::Project', Match.objectLike({
       Environment: Match.objectLike({
@@ -332,7 +332,7 @@ describe('with standard pipeline', () => {
       }),
     }));
   });
-  
+
   test('can provide a service role used for signing codebuild operations', () => {
     // GIVEN
     const signingBucket = Bucket.fromBucketName(stack, 'SigningBucket', 'signing-bucket');

--- a/lib/__tests__/signing.test.ts
+++ b/lib/__tests__/signing.test.ts
@@ -51,7 +51,7 @@ describe('with standard pipeline', () => {
           {
             Name: 'SCRIPT_S3_KEY',
             Type: 'PLAINTEXT',
-            Value: '66e3222b91cee523319206cf101a1193eaf9183d5b9f37546df8cba771ca079e.zip',
+            Value: '57b2661c55d0400ef7c5db10e1d13ea42db5520c0338de4ca7cf407f8cc325e2.zip',
           },
           {
             Name: 'SIGNING_BUCKET_NAME',
@@ -101,16 +101,6 @@ describe('with standard pipeline', () => {
                 ],
               ],
             },
-          },
-          {
-            Name: 'SIGNER_PROFILE_NAME',
-            Type: 'PLAINTEXT',
-            Value: 'profile-name',
-          },
-          {
-            Name: 'SIGNER_PROFILE_OWNER',
-            Type: 'PLAINTEXT',
-            Value: 'profile-owner',
           },
         ],
         Image: 'public.ecr.aws/jsii/superchain:1-buster-slim-node18',
@@ -277,7 +267,7 @@ describe('with standard pipeline', () => {
           {
             Name: 'SCRIPT_S3_KEY',
             Type: 'PLAINTEXT',
-            Value: '66e3222b91cee523319206cf101a1193eaf9183d5b9f37546df8cba771ca079e.zip',
+            Value: '57b2661c55d0400ef7c5db10e1d13ea42db5520c0338de4ca7cf407f8cc325e2.zip',
           },
           {
             Name: 'SIGNING_BUCKET_NAME',

--- a/lib/signing.ts
+++ b/lib/signing.ts
@@ -92,11 +92,11 @@ export class SignNuGetWithSigner extends Construct implements ISigner {
     };
 
     if (props.signerProfileName) {
-      environment.SIGNER_PROFILE_NAME = props.signerProfileName;
+      environment['SIGNER_PROFILE_NAME'] = props.signerProfileName;
     }
 
     if (props.signerProfileOwner) {
-      environment.SIGNER_PROFILE_OWNER = props.signerProfileOwner;
+      environment['SIGNER_PROFILE_OWNER'] = props.signerProfileOwner;
     }
 
     const shellable = new Shellable(this, 'Default', {

--- a/lib/signing.ts
+++ b/lib/signing.ts
@@ -59,7 +59,7 @@ export interface SignNuGetWithSignerProps {
    * @default no signing profile owner
    */
   readonly signerProfileOwner?: string;
-  
+
   /*
    * The service role that will be used to allow CodeBuild to perform operations
    * on your behalf.

--- a/lib/signing.ts
+++ b/lib/signing.ts
@@ -92,11 +92,11 @@ export class SignNuGetWithSigner extends Construct implements ISigner {
     };
 
     if (props.signerProfileName) {
-      environment['SIGNER_PROFILE_NAME'] = props.signerProfileName;
+      environment.SIGNER_PROFILE_NAME = props.signerProfileName;
     }
 
     if (props.signerProfileOwner) {
-      environment['SIGNER_PROFILE_OWNER'] = props.signerProfileOwner;
+      environment.SIGNER_PROFILE_OWNER = props.signerProfileOwner;
     }
 
     const shellable = new Shellable(this, 'Default', {

--- a/lib/signing.ts
+++ b/lib/signing.ts
@@ -49,14 +49,14 @@ export interface SignNuGetWithSignerProps {
   /**
    * The name of the signer profile to use for signing
    *
-   * @default profile-name
+   * @default no signing profile name
    */
   readonly signerProfileName?: string;
 
   /**
    * The owner of the signer profile to use for signing
    *
-   * @default profile-owner
+   * @default no signing profile owner
    */
   readonly signerProfileOwner?: string;
 
@@ -77,13 +77,19 @@ export class SignNuGetWithSigner extends Construct implements ISigner {
   public constructor(scope: Construct, id: string, props: SignNuGetWithSignerProps) {
     super(scope, id);
 
-    const environment = {
+    const environment: { [key: string]: string } = {
       SIGNING_BUCKET_NAME: props.signingBucket.bucketName,
       SIGNING_LAMBDA_ARN: props.signingLambda.functionArn,
       ACCESS_ROLE_ARN: props.accessRole.roleArn,
-      SIGNER_PROFILE_NAME: props.signerProfileName ?? 'profile-name',
-      SIGNER_PROFILE_OWNER: props.signerProfileOwner ?? 'profile-owner',
     };
+
+    if (props.signerProfileName) {
+      environment.SIGNER_PROFILE_NAME = props.signerProfileName;
+    }
+
+    if (props.signerProfileOwner) {
+      environment.SIGNER_PROFILE_OWNER = props.signerProfileOwner;
+    }
 
     const shellable = new Shellable(this, 'Default', {
       platform: new LinuxPlatform(props.buildImage ?? LinuxBuildImage.fromDockerRegistry('public.ecr.aws/jsii/superchain:1-buster-slim-node18')),

--- a/lib/signing.ts
+++ b/lib/signing.ts
@@ -47,6 +47,20 @@ export interface SignNuGetWithSignerProps {
   readonly accessRole: IRole;
 
   /**
+   * The name of the signer profile to use for signing
+   *
+   * @default profile-name
+   */
+  readonly signerProfileName?: string;
+
+  /**
+   * The owner of the signer profile to use for signing
+   *
+   * @default profile-owner
+   */
+  readonly signerProfileOwner?: string;
+
+  /**
    * The build image to do the signing in
    *
    * Needs to have NuGet preinstalled.
@@ -67,6 +81,8 @@ export class SignNuGetWithSigner extends Construct implements ISigner {
       SIGNING_BUCKET_NAME: props.signingBucket.bucketName,
       SIGNING_LAMBDA_ARN: props.signingLambda.functionArn,
       ACCESS_ROLE_ARN: props.accessRole.roleArn,
+      SIGNER_PROFILE_NAME: props.signerProfileName ?? 'profile-name',
+      SIGNER_PROFILE_OWNER: props.signerProfileOwner ?? 'profile-owner',
     };
 
     const shellable = new Shellable(this, 'Default', {

--- a/lib/signing/nuget/sign.sh
+++ b/lib/signing/nuget/sign.sh
@@ -33,7 +33,7 @@ for nuget_package_path in $(find dotnet -name *.nupkg -not -iname *.symbols.nupk
     version_id=$(aws s3api put-object \
       --bucket ${SIGNING_BUCKET_NAME:-} \
       --key unsigned/${file} \
-      --body ${file} | jq -r '.VersionId')
+      --body ${tmp}/${file} | jq -r '.VersionId')
     # invoke signer lambda
     aws lambda invoke \
       --function-name ${SIGNING_LAMBDA_ARN:-} \

--- a/lib/signing/nuget/sign.sh
+++ b/lib/signing/nuget/sign.sh
@@ -39,7 +39,7 @@ for nuget_package_path in $(find dotnet -name *.nupkg -not -iname *.symbols.nupk
       --function-name ${SIGNING_LAMBDA_ARN:-} \
       --invocation-type RequestResponse \
       --cli-binary-format raw-in-base64-out \
-      --payload '{ "artifactKey": "'"unsigned/${file}"'", "artifactVersion": "'"${version_id}"'" }' \
+      --payload '{ "artifactKey": "'"unsigned/${file}"'", "artifactVersion": "'"${version_id}"'", "profileName": "'"${SIGNER_PROFILE_NAME:-}"'", "profileOwner": "'"${SIGNER_PROFILE_OWNER:-}"'" }' \
       ${tmp}/response.json >/dev/null
     signed_artifact_key=$(cat ${tmp}/response.json | jq -r '.signedArtifactKey')
     # download signed dll from signer bucket


### PR DESCRIPTION
This PR adds properties on the `SignNuGetWithSignerProps` interface that allow a user to specify the profile and owner that will be used for signing. These properties are added as environment variables that are passed in the payload to the signing lambda as part of the`sign.sh` script. The signing lambda can utilize these values to start the signing job with the specified signer profile and owner. In addition to the above changes, `sign.sh` has been updated to provided the entire path of the dll file to upload to the signing bucket. This fixes an error where the --body value must be a full path.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.