### PR TITLE
fix: Warning: installLatestAwsSdk was not specified

### DIFF
--- a/lib/registry-sync/ecr-mirror.ts
+++ b/lib/registry-sync/ecr-mirror.ts
@@ -183,6 +183,7 @@ export class EcrMirror extends Construct {
 
     if (props.autoStart) {
       new cr.AwsCustomResource(this, 'BuildExecution', {
+        installLatestAwsSdk: false,
         policy: cr.AwsCustomResourcePolicy.fromSdkCalls({ resources: [this._project.projectArn] }),
         onUpdate: {
           action: 'startBuild',


### PR DESCRIPTION
We do not need the latest SDK version for this command. This will disable the warning and also make it slightly faster.

Fixes warnings like this:
```
[Warning at /MyStack/EcrRegistry/EcrMirror/BuildExecution] installLatestAwsSdk was not specified, and defaults to true. You probably do not want this. Set the global context flag '@aws-cdk/customresources:installLatestAwsSdkDefault' to false to switch this behavior off project-wide, or set the property explicitly to true if you know you need to call APIs that are not in Lambda's built-in SDK version. [ack: @aws-cdk/custom-resources:installLatestAwsSdkNotSpecified]
```

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.