### PR TITLE
chore: remove preinstall from windows

### DIFF
--- a/lib/shellable.ts
+++ b/lib/shellable.ts
@@ -547,11 +547,7 @@ export class WindowsPlatform extends ShellPlatform {
   public readonly platformType = PlatformType.Windows;
 
   public installCommands(): string[] | undefined {
-    return [
-      // Update the image's nodejs to the latest LTS release.
-      'Import-Module "C:\\ProgramData\\chocolatey\\helpers\\chocolateyProfile.psm1"',
-      'C:\\ProgramData\\chocolatey\\bin\\choco.exe upgrade nodejs-lts -y',
-    ];
+    return undefined;
   }
 
   public prebuildCommands(assumeRole?: AssumeRole, _useRegionalStsEndpoints?: boolean): string[] {


### PR DESCRIPTION
All supported CodeBuild versions of Windows now come with node preinstalled. The download process frequently fails. Removing it will reduce noise.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.