### PR TITLE
fix(gpg resource): survive errors during cleanup

### DIFF
--- a/lib/custom-resource-handlers/src/_rmrf.ts
+++ b/lib/custom-resource-handlers/src/_rmrf.ts
@@ -8,13 +8,18 @@ const stat = util.promisify(fs.stat);
 const unlink = util.promisify(fs.unlink);
 
 export = async function _rmrf(filePath: string): Promise<void> {
-  const fstat = await stat(filePath);
-  if (fstat.isDirectory()) {
-    for (const child of await readdir(filePath)) {
-      await _rmrf(path.join(filePath, child));
+  // All of this is best-effort
+  try {
+    const fstat = await stat(filePath);
+    if (fstat.isDirectory()) {
+      for (const child of await readdir(filePath)) {
+        await _rmrf(path.join(filePath, child));
+      }
+      await rmdir(filePath);
+    } else {
+      await unlink(filePath);
     }
-    await rmdir(filePath);
-  } else {
-    await unlink(filePath);
+  } catch (e: any) {
+    // If deleting fails, too bad.
   }
 };


### PR DESCRIPTION
When the GPG agent is shutdown, it removes some UNIX sockets from the temporary directory. Their removal may race with the `rmrf` that we run in the custom resource, leading to an `ENOENT` error.

Catch it and continue. Ultimately, this code runs in a Lambda and all files are going to disappear anyway.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.