### PR TITLE
fix: maven staging timeout

### DIFF
--- a/lib/publishing/maven/publish-mvn.sh
+++ b/lib/publishing/maven/publish-mvn.sh
@@ -116,6 +116,7 @@ $mvn --settings=${mvn_settings}                                                 
     -DnexusUrl=${MAVEN_ENDPOINT:-https://oss.sonatype.org}                         \
     -DserverId=ossrh                                                               \
     -DautoReleaseAfterClose=true                                                   \
+    -DstagingProgressTimeoutMinutes=10                                             \
     -DstagingProfileId=${STAGING_PROFILE_ID} | tee ${staging_output}
 
 # we need to consule PIPESTATUS sinec "tee" is the last command


### PR DESCRIPTION
Maven staging often takes longer than the default 5 minutes. Increase to 10.

Currently we are seeing the following error:

```console
Waiting for operation to complete...
....................................................................................................
[WARNING] TIMEOUT after 302.4 s
[ERROR] Rule failure while trying to close staging repository with ID "softwareamazon-7956".
[ERROR] 
[ERROR] Nexus Staging Rules Failure Report
[ERROR] ==================================
[ERROR] 
[ERROR] 
[ERROR] Cleaning up local stage directory after a Rule failure during close of staging repositories: []
[ERROR]  * Deleting context 4714fd1f794.properties
[ERROR] Cleaning up remote stage repositories after a Rule failure during close of staging repositories: []
[ERROR]  * Dropping failed staging repository with ID "softwareamazon-7956" (Rule failure during close of staging repositories: []).
```

### Side note

We already implemented this change years ago in publib, we should really switch over to publib.

See https://github.com/cdklabs/publib/pull/30

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.