### PR TITLE
feat(package-integrity): can pass env vars to integrity build

### DIFF
--- a/lib/__tests__/package-integrity/integrity.test.ts
+++ b/lib/__tests__/package-integrity/integrity.test.ts
@@ -7,7 +7,6 @@ import { Template, Match } from 'aws-cdk-lib/assertions';
 import { LinuxPlatform, PackageIntegrityValidation } from '../..';
 
 test('creates a codebuild project that triggers daily and runs the integrity handler', () => {
-
   const stack = new Stack(new App(), 'TestStack');
   const token = sm.Secret.fromSecretCompleteArn(stack, 'GitHubSecret', 'arn:aws:secretsmanager:us-east-1:123456789123:secret:github-token-000000');
 
@@ -61,25 +60,39 @@ test('creates a codebuild project that triggers daily and runs the integrity han
       ]),
     },
   });
+});
 
-  // expect(template.Resources.IntegrityD83C2C0B.Properties.Environment.EnvironmentVariables.slice(2)).toStrictEqual(
-  //   [
-  //     {
-  //       Name: 'GITHUB_REPOSITORY',
-  //       Type: 'PLAINTEXT',
-  //       Value: 'cdklabs/some-repo',
-  //     },
-  //     {
-  //       Name: 'TAG_PREFIX',
-  //       Type: 'PLAINTEXT',
-  //       Value: '',
-  //     },
-  //     {
-  //       Name: 'GITHUB_TOKEN_ARN',
-  //       Type: 'PLAINTEXT',
-  //       Value: 'arn:aws:secretsmanager:us-east-1:123456789123:secret:github-token-000000',
-  //     },
-  //   ],
-  // );
+test('can pass environment variables to the integrity handler code build project', () => {
+  const stack = new Stack(new App(), 'TestStack');
+  const token = sm.Secret.fromSecretCompleteArn(stack, 'GitHubSecret', 'arn:aws:secretsmanager:us-east-1:123456789123:secret:github-token-000000');
 
+  new PackageIntegrityValidation(stack, 'Integrity', {
+    buildPlatform: new LinuxPlatform(codebuild.LinuxBuildImage.fromDockerRegistry('jsii/superchain:1-bullseye-slim-node14')),
+    githubTokenSecret: token,
+    repository: 'cdklabs/some-repo',
+    environment: {
+      FOO: 'bar'
+    },
+    environmentSecrets: {
+      SECRET: 'arn:aws:secretsmanager:us-east-1:123456789123:secret:super-secret-token-000000'
+    }
+  });
+
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::CodeBuild::Project', {
+    Environment: {
+      EnvironmentVariables: Match.arrayWith([
+        {
+          Name: 'FOO',
+          Type: 'PLAINTEXT',
+          Value: 'bar',
+        },
+        {
+          Name: 'SECRET',
+          Type: 'SECRETS_MANAGER',
+          Value: 'super-secret-token',
+        },
+      ]),
+    },
+  });
 });

--- a/lib/__tests__/package-integrity/integrity.test.ts
+++ b/lib/__tests__/package-integrity/integrity.test.ts
@@ -71,11 +71,11 @@ test('can pass environment variables to the integrity handler code build project
     githubTokenSecret: token,
     repository: 'cdklabs/some-repo',
     environment: {
-      FOO: 'bar'
+      FOO: 'bar',
     },
     environmentSecrets: {
-      SECRET: 'arn:aws:secretsmanager:us-east-1:123456789123:secret:super-secret-token-000000'
-    }
+      SECRET: 'arn:aws:secretsmanager:us-east-1:123456789123:secret:super-secret-token-000000',
+    },
   });
 
   const template = Template.fromStack(stack);

--- a/lib/package-integrity/handler/integrity.ts
+++ b/lib/package-integrity/handler/integrity.ts
@@ -196,7 +196,7 @@ export class RepositoryIntegrity {
 }
 
 /**
- * NpmIntegiry is able to perform integiry checks against packages stored on npmjs.com
+ * NpmIntegrity is able to perform integrity checks against packages stored on npmjs.com
  */
 export class NpmArtifactIntegrity extends ArtifactIntegrity {
 

--- a/lib/package-integrity/integrity.ts
+++ b/lib/package-integrity/integrity.ts
@@ -61,6 +61,26 @@ export interface PackageIntegrityValidationProps {
    */
   readonly packTask?: string;
 
+  /**
+   * Additional environment variables to set.
+   *
+   * @default - No additional environment variables
+   */
+  readonly environment?: { [key: string]: string | undefined };
+
+  /**
+   * Environment variables with secrets manager values. The values must be complete Secret Manager ARNs.
+   *
+   * @default no additional environment variables
+   */
+  readonly environmentSecrets?: { [key: string]: string };
+
+  /**
+   * Environment variables with SSM parameter values.
+   *
+   * @default no additional environment variables
+   */
+  readonly environmentParameters?: { [key: string]: string };  
 }
 
 /**
@@ -88,7 +108,11 @@ export class PackageIntegrityValidation extends Construct {
       entrypoint: 'validate.sh',
       privileged: props.privileged ?? false,
       platform: props.buildPlatform ?? ShellPlatform.LinuxUbuntu,
+      environmentSecrets: props.environmentSecrets,
+      environmentParameters: props.environmentParameters,
       environment: {
+        ...props.environment,
+        // always override the env vars we have explicit options for
         GITHUB_REPOSITORY: props.repository,
         TAG_PREFIX: props.tagPrefix ?? '',
         GITHUB_TOKEN_ARN: props.githubTokenSecret?.secretArn,

--- a/lib/package-integrity/integrity.ts
+++ b/lib/package-integrity/integrity.ts
@@ -80,7 +80,7 @@ export interface PackageIntegrityValidationProps {
    *
    * @default no additional environment variables
    */
-  readonly environmentParameters?: { [key: string]: string };  
+  readonly environmentParameters?: { [key: string]: string };
 }
 
 /**


### PR DESCRIPTION
Some builds will require env vars set to run a build correctly or authenticate with upstream services. Allow passing through all types of CodeBuild env vars to the underlying Shellable job.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.