### PR TITLE
fix(maven): publishing to Maven does not work

### DIFF
--- a/lib/publishing/maven/with-signing-key.sh
+++ b/lib/publishing/maven/with-signing-key.sh
@@ -37,7 +37,7 @@ else
     }
 
     export KEY_AVAILABLE=true
-    export MAVEN_GPG_PRIVATE_KEY=$(value-from-secret Passphrase)
+    export MAVEN_GPG_PRIVATE_KEY=$(value-from-secret PrivateKey)
     export MAVEN_GPG_PRIVATE_KEY_PASSPHRASE=$(value-from-secret Passphrase)
 fi
 


### PR DESCRIPTION
In #1949 I made a copy/paste-o, reading the same field from the Secrets Manager Secret twice instead of reading both fields.

Fix the typo.


-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.