### PR TITLE
fix(Maven): Update publish.sh to not publish to Maven when FOR_REAL is not true

### DIFF
--- a/lib/publishing/maven/publish.sh
+++ b/lib/publishing/maven/publish.sh
@@ -10,6 +10,18 @@ if [[ ! -d ./java ]]; then
     exit 1
 fi
 
+if [[ "${FOR_REAL:-}" == "true" ]]; then
+    echo "Publishing to Maven"
+    unset MAVEN_DRYRUN
+else
+    echo "==========================================="
+    echo "            🏜️ DRY-RUN MODE 🏜️"
+    echo
+    echo "Set FOR_REAL=true to do actual publishing!"
+    echo "==========================================="
+    export MAVEN_DRYRUN='true'
+fi
+
 echo "Getting credentials..."
 credentials=$(aws secretsmanager get-secret-value --secret-id ${MAVEN_LOGIN_SECRET} --output=text --query=SecretString)
 


### PR DESCRIPTION
[PR 1949](https://github.com/cdklabs/aws-delivlib/pull/1949) dropped the reference to FOR_REAL that controlled whether to publish in Test environments. This PR replaces that functionality.

It was tested in the Test and Release environments of AWS Solutions Constructs.

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.