### PR TITLE
feat: support `runtime-versions` in BuildSpec

### DIFF
--- a/lib/__tests__/build-spec.test.ts
+++ b/lib/__tests__/build-spec.test.ts
@@ -1,6 +1,5 @@
 import * as delivlib from '../../lib';
 
-
 test('buildspec single artifact goes to "artifacts"', () => {
   const bs = delivlib.BuildSpec.simple({
     build: ['echo hello > foo/file.txt'],
@@ -63,5 +62,234 @@ test('buildspec multiple artifacts all go into "secondary-artifacts"', () => {
       },
     },
     version: '0.2',
+  });
+});
+
+test('buildspec empty creates minimal structure', () => {
+  const bs = delivlib.BuildSpec.empty();
+  const rendered = bs.render();
+
+  expect(rendered).toEqual({
+    version: '0.2',
+  });
+});
+
+test('buildspec literal accepts raw structure', () => {
+  const struct = {
+    version: '0.2' as const,
+    phases: {
+      build: {
+        commands: ['echo test'],
+      },
+    },
+  };
+
+  const bs = delivlib.BuildSpec.literal(struct);
+  const rendered = bs.render();
+
+  expect(rendered).toEqual(struct);
+});
+
+test('buildspec simple with all phases', () => {
+  const bs = delivlib.BuildSpec.simple({
+    install: ['npm install'],
+    preBuild: ['npm run lint'],
+    build: ['npm run build'],
+    artifactDirectory: 'dist',
+  });
+
+  const rendered = bs.render();
+
+  expect(rendered).toEqual({
+    version: '0.2',
+    phases: {
+      install: {
+        commands: ['npm install'],
+      },
+      pre_build: {
+        commands: ['npm run lint'],
+      },
+      build: {
+        commands: ['npm run build'],
+      },
+    },
+    artifacts: {
+      'base-directory': 'dist',
+      'files': ['**/*'],
+    },
+  });
+});
+
+test('buildspec simple with reports', () => {
+  const bs = delivlib.BuildSpec.simple({
+    build: ['npm test'],
+    reports: {
+      jest: {
+        'files': ['coverage/clover.xml'],
+        'file-format': 'CucumberJson',
+      },
+    },
+  });
+
+  const rendered = bs.render();
+
+  expect(rendered.reports).toEqual({
+    jest: {
+      'files': ['coverage/clover.xml'],
+      'file-format': 'CucumberJson',
+    },
+  });
+});
+
+test('additionalArtifactNames returns correct names', () => {
+  const bs = delivlib.BuildSpec.simple({
+    build: ['echo test'],
+    artifactDirectory: 'dist',
+    additionalArtifactDirectories: {
+      docs: 'documentation',
+      assets: 'static',
+    },
+  });
+
+  expect(bs.additionalArtifactNames).toEqual(['docs', 'assets']);
+});
+
+test('additionalArtifactNames excludes PRIMARY', () => {
+  const bs = delivlib.BuildSpec.simple({
+    build: ['echo test'],
+    artifactDirectory: 'dist',
+  });
+
+  expect(bs.additionalArtifactNames).toEqual([]);
+});
+
+test('merge combines two buildspecs', () => {
+  const bs1 = delivlib.BuildSpec.simple({
+    install: ['npm install'],
+    build: ['npm run build'],
+  });
+
+  const bs2 = delivlib.BuildSpec.simple({
+    preBuild: ['npm run lint'],
+    build: ['npm run test'],
+  });
+
+  const merged = bs1.merge(bs2);
+  const rendered = merged.render();
+
+  expect(rendered.phases).toEqual({
+    install: {
+      commands: ['npm install'],
+    },
+    pre_build: {
+      commands: ['npm run lint'],
+    },
+    build: {
+      commands: ['npm run build', 'npm run test'],
+    },
+  });
+});
+
+test('merge throws on duplicate artifact names', () => {
+  const bs1 = delivlib.BuildSpec.simple({
+    additionalArtifactDirectories: { docs: 'docs1' },
+  });
+
+  const bs2 = delivlib.BuildSpec.simple({
+    additionalArtifactDirectories: { docs: 'docs2' },
+  });
+
+  expect(() => bs1.merge(bs2)).toThrow('There is already an artifact with name docs');
+});
+
+test('merge throws on duplicate report names', () => {
+  const bs1 = delivlib.BuildSpec.simple({
+    reports: { test: { files: ['test1.xml'] } },
+  });
+
+  const bs2 = delivlib.BuildSpec.simple({
+    reports: { test: { files: ['test2.xml'] } },
+  });
+
+  expect(() => bs1.merge(bs2)).toThrow('Reports must have unique names');
+});
+
+test('render throws when PRIMARY artifact name not supplied', () => {
+  const bs = delivlib.BuildSpec.simple({
+    artifactDirectory: 'dist',
+    additionalArtifactDirectories: { docs: 'documentation' },
+  });
+
+  expect(() => bs.render()).toThrow('Replacement name for PRIMARY artifact not supplied');
+});
+
+test('merge handles environment variables', () => {
+  const bs1 = delivlib.BuildSpec.literal({
+    version: '0.2',
+    env: {
+      variables: { NODE_ENV: 'production' },
+    },
+  });
+
+  const bs2 = delivlib.BuildSpec.literal({
+    version: '0.2',
+    env: {
+      variables: { DEBUG: 'true' },
+    },
+  });
+
+  const merged = bs1.merge(bs2);
+  const rendered = merged.render();
+
+  expect(rendered.env?.variables).toEqual({
+    NODE_ENV: 'production',
+    DEBUG: 'true',
+  });
+});
+
+test('merge handles cache paths', () => {
+  const bs1 = delivlib.BuildSpec.literal({
+    version: '0.2',
+    cache: { paths: ['node_modules/**/*'] },
+  });
+
+  const bs2 = delivlib.BuildSpec.literal({
+    version: '0.2',
+    cache: { paths: ['.npm/**/*'] },
+  });
+
+  const merged = bs1.merge(bs2);
+  const rendered = merged.render();
+
+  expect(rendered.cache?.paths).toEqual(['node_modules/**/*', '.npm/**/*']);
+});
+
+test('merge handles install phase runtime-versions', () => {
+  const bs1 = delivlib.BuildSpec.literal({
+    version: '0.2',
+    phases: {
+      install: {
+        'commands': ['echo install'],
+        'runtime-versions': { nodejs: '18' },
+      },
+    },
+  });
+
+  const bs2 = delivlib.BuildSpec.literal({
+    version: '0.2',
+    phases: {
+      install: {
+        'commands': ['npm install'],
+        'runtime-versions': { python: '3.9' },
+      },
+    },
+  });
+
+  const merged = bs1.merge(bs2);
+  const rendered = merged.render();
+
+  expect(rendered.phases?.install).toEqual({
+    'commands': ['echo install', 'npm install'],
+    'runtime-versions': { nodejs: '18', python: '3.9' },
   });
 });


### PR DESCRIPTION
This PR enhances the BuildSpec class with comprehensive test coverage and improves the merge functionality.
Updates types to cover previously missing fields, all according to the [official docs](https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#build-spec-ref-syntax).

## Changes

- Add comprehensive test suite for BuildSpec class covering all methods and edge cases
- Improve merge functionality to properly handle runtime-versions in install phase
- Add support for on-failure phase configuration in merge operations
- Enhance type definitions with InstallPhaseStruct interface for better type safety
- Fix merge function to properly handle phase-specific properties with correct typing

## Testing

- All existing tests continue to pass
- New comprehensive test suite covers previously untested functionality
- Tests validate proper merging behavior for all BuildSpec features

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.