### PR TITLE
feat(auto-build): add timeout property to AutoBuildOptions

### DIFF
--- a/lib/__tests__/auto-build.test.ts
+++ b/lib/__tests__/auto-build.test.ts
@@ -1,4 +1,4 @@
-import { App, Stack } from 'aws-cdk-lib';
+import { App, Duration, Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { Artifacts } from 'aws-cdk-lib/aws-codebuild';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
@@ -151,5 +151,20 @@ test('can enable artifacts', () => {
       Packaging: 'ZIP',
       Type: 'S3',
     },
+  });
+});
+
+test('can configure timeout', () => {
+  new AutoBuild(stack, 'AutoBuild', {
+    repo: new GitHubRepo({
+      repository: 'some-owner/some-repo',
+      tokenSecretArn: 'arn:aws:secretsmanager:someregion:someaccount:secret:sometoken',
+    }),
+    timeout: Duration.hours(4),
+  });
+  const template = Template.fromStack(stack);
+
+  template.hasResourceProperties('AWS::CodeBuild::Project', {
+    TimeoutInMinutes: 240,
   });
 });

--- a/lib/auto-build.ts
+++ b/lib/auto-build.ts
@@ -1,4 +1,5 @@
 import {
+  Duration,
   SecretValue,
   aws_codebuild as codebuild,
   aws_iam as iam,
@@ -70,6 +71,13 @@ export interface AutoBuildOptions {
    * ARTIFACTS
    */
   readonly artifacts?: codebuild.IArtifacts;
+
+  /**
+   * The number of minutes after which the build times out.
+   *
+   * @default Duration.hours(1)
+   */
+  readonly timeout?: Duration;
 }
 
 export interface AutoBuildProps extends AutoBuildOptions {
@@ -119,6 +127,7 @@ export class AutoBuild extends Construct {
       buildSpec: props.buildSpec,
       artifacts: props.artifacts,
       ssmSessionPermissions: true,
+      timeout: props.timeout,
     });
     this.project.role!.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonElasticContainerRegistryPublicReadOnly'));
 


### PR DESCRIPTION
## Problem

`AutoBuild` does not expose a `timeout` property, forcing consumers to use the CDK L1 escape hatch to configure the CodeBuild project timeout.

The default 60-minute timeout is insufficient for large builds like `aws-cdk-private` which takes ~54+ minutes for build + Rosetta (~29,634 snippets) + pack.

## Solution

Add an optional `timeout` property to `AutoBuildOptions` that passes through to the underlying `codebuild.Project`.

```typescript
new AutoBuild(this, 'AutoBuild', {
  repo,
  timeout: Duration.hours(4),
});
```

## Testing

- `npx projen build` passes (includes compile + tests)
- No snapshot changes required (property is optional, defaults unchanged)