### PR TITLE
chore: upgrade Lambda runtime from Node.js 20 to Node.js 22

### DIFF
--- a/lib/__tests__/expected.yml
+++ b/lib/__tests__/expected.yml
@@ -1169,7 +1169,7 @@ Resources:
         Fn::GetAtt:
           - CodeCommitPipelinePipelineWatcherPollerServiceRole0A1D8005
           - Arn
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
     DependsOn:
       - CodeCommitPipelinePipelineWatcherPollerServiceRoleDefaultPolicyE2104AD1
       - CodeCommitPipelinePipelineWatcherPollerServiceRole0A1D8005
@@ -4418,7 +4418,7 @@ Resources:
         Fn::GetAtt:
           - CodeCommitPipelineChangeControllerFunctionServiceRoleF02841DB
           - Arn
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Timeout: 300
     DependsOn:
       - CodeCommitPipelineChangeControllerFunctionServiceRoleDefaultPolicy315F7AF5
@@ -4802,7 +4802,7 @@ Resources:
         Fn::GetAtt:
           - CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092
           - Arn
-      Runtime: nodejs20.x
+      Runtime: nodejs22.x
       Description:
         Fn::Join:
           - ""

--- a/lib/change-controller.ts
+++ b/lib/change-controller.ts
@@ -79,7 +79,7 @@ export class ChangeController extends Construct {
     const fn = new nodejs.NodejsFunction(this, 'Function', {
       description: `Enforces a Change Control Policy into CodePipeline's ${props.pipelineStage.stageName} stage`,
       entry: path.join(__dirname, 'change-control-lambda', 'index.ts'),
-      runtime: lambda.Runtime.NODEJS_20_X,
+      runtime: lambda.Runtime.NODEJS_22_X,
       environment: {
         // CAPITAL punishment 👌🏻
         CHANGE_CONTROL_BUCKET_NAME: changeControlBucket.bucketName,

--- a/lib/chime-notifier/chime-notifier.ts
+++ b/lib/chime-notifier/chime-notifier.ts
@@ -56,7 +56,7 @@ export class ChimeNotifier extends Construct {
         handler: 'index.handler',
         uuid: '0f4a3ee0-692e-4249-932f-a46a833886d8',
         code: lambda.Code.fromAsset(path.join(__dirname, 'handler')),
-        runtime: lambda.Runtime.NODEJS_20_X,
+        runtime: lambda.Runtime.NODEJS_22_X,
         timeout: Duration.minutes(5),
       });
 

--- a/lib/pipeline-watcher/watcher.ts
+++ b/lib/pipeline-watcher/watcher.ts
@@ -53,7 +53,7 @@ export class PipelineWatcher extends Construct {
 
     const pipelineWatcher = new lambda.Function(this, 'Poller', {
       handler: 'watcher-handler.handler',
-      runtime: lambda.Runtime.NODEJS_20_X,
+      runtime: lambda.Runtime.NODEJS_22_X,
       code: lambda.Code.fromAsset(path.join(__dirname, 'handler')),
       environment: {
         METRIC_NAMESPACE: props.metricNamespace,


### PR DESCRIPTION
## Summary

Upgrade all Lambda function runtimes from `NODEJS_20_X` to `NODEJS_22_X`.

Node.js 20 reached end-of-life on 2026-05-01. After this date, AWS Lambda no longer applies security patches. Lambda will block function create/update operations starting March 2027.

## Changes

- `lib/pipeline-watcher/watcher.ts` — Pipeline watcher poller Lambda
- `lib/chime-notifier/chime-notifier.ts` — Chime failure notification Lambda
- `lib/change-controller.ts` — Change controller Lambda
- `lib/__tests__/expected.yml` — Updated test snapshot

## Testing

Ran `yarn compile && yarn test` locally on Node.js 22.23.1:
- 162 tests pass, 4 pre-existing failures in `package-integrity` (unrelated — same failures on `main`)
- Zero new test failures introduced by this change

The Lambda handler code is basic Node.js (AWS SDK calls, HTTPS requests) with no dependencies on Node.js 20-specific APIs. Node.js 22 is fully backwards compatible for these use cases.