### PR TITLE
fix(test): pin toolchain in package-integrity fixtures

### DIFF
--- a/lib/__tests__/package-integrity/handler/__fixtures__/projen-jsii-project/.projenrc.js
+++ b/lib/__tests__/package-integrity/handler/__fixtures__/projen-jsii-project/.projenrc.js
@@ -16,6 +16,15 @@ const project = new cdk.JsiiProject({
   repositoryUrl: 'dummy',
   projenVersion,
   jsiiVersion: '^5',
+  // Pin the test toolchain. projen otherwise generates "typescript": "*",
+  // "jest": "*" and "ts-jest": "*", which resolve the latest published
+  // versions at test time. TypeScript 7.x now resolves via "*" and is
+  // incompatible with ts-jest 29 (peer typescript ">=4.3 <6"), crashing with
+  // "Cannot read properties of undefined (reading 'readFile')". Pin to a
+  // compatible combination so this scaffolded project builds deterministically.
+  typescriptVersion: '~5.8.0',
+  jestOptions: { jestVersion: '^29' },
+  devDeps: ['ts-jest@^29'],
   tsconfigDev: {
     compilerOptions: {
       types: ['jest', 'node'],
@@ -26,4 +35,3 @@ const project = new cdk.JsiiProject({
 project.package.addField('private', true);
 
 project.synth();
-

--- a/lib/__tests__/package-integrity/handler/__fixtures__/projen-non-jsii-project/.projenrc.js
+++ b/lib/__tests__/package-integrity/handler/__fixtures__/projen-non-jsii-project/.projenrc.js
@@ -11,6 +11,15 @@ const project = new typescript.TypeScriptProject({
   authorAddress: 'dummy@example.com',
   repositoryUrl: 'dummy',
   projenVersion,
+  // Pin the test toolchain. projen otherwise generates "typescript": "*",
+  // "jest": "*" and "ts-jest": "*", which resolve the latest published
+  // versions at test time. TypeScript 7.x now resolves via "*" and is
+  // incompatible with ts-jest 29 (peer typescript ">=4.3 <6"), crashing with
+  // "Cannot read properties of undefined (reading 'readFile')". Pin to a
+  // compatible combination so this scaffolded project builds deterministically.
+  typescriptVersion: '~5.8.0',
+  jestOptions: { jestVersion: '^29' },
+  devDeps: ['ts-jest@^29'],
   tsconfigDev: {
     compilerOptions: {
       types: ['jest', 'node'],
@@ -21,4 +30,3 @@ const project = new typescript.TypeScriptProject({
 project.package.addField('private', true);
 
 project.synth();
-


### PR DESCRIPTION
## Problem

`chore(deps)` dependency-upgrade PRs (e.g. #2054) are stuck — the required `build` check fails on the `package-integrity` test suite (`lib/__tests__/package-integrity/handler/integrity.test.ts`: `happy jsii`, `unhappy npm jsii`, `unhappy pypi jsii`, `happy ts`).

These tests scaffold throwaway projen projects and run `npx projen build` inside them. The fixture `.projenrc.js` files pin **no** versions, so projen generates:

```jsonc
"typescript": "*",
"jest": "*",
"ts-jest": "*"
```

which resolve the **latest published** versions at test time. TypeScript **7.0.2** now resolves via `*`, but `ts-jest@29` only supports `typescript ">=4.3 <6"`. The nested build therefore crashes:

```
TypeError: Cannot read properties of undefined (reading 'readFile')
  at ConfigSet._resolveTsConfig (node_modules/ts-jest/dist/legacy/config/config-set.js:519:76)
```

No `dist/` is produced, so the outer assertions fail with `ENOENT ... /dist`. This is repo-wide (affects `main` and every open PR), not specific to any dependency bump.

## Fix

Pin the scaffolded projects to a compatible combination in both fixtures:

```js
typescriptVersion: '~5.8.0',
jestOptions: { jestVersion: '^29' },
devDeps: ['ts-jest@^29'],
```

## Validation

Reproduced locally: with `*` ranges → typescript `7.0.2` + ts-jest `29.4.11` → `readFile` crash. After pinning → typescript `5.8.3` + jest `29.7.0` + ts-jest `29.4.11`, and the scaffolded project's test step passes (`Test Suites: 1 passed`). CI will exercise the full `npx projen build` in the integrity suite.
